### PR TITLE
Fix non-relative paths in breadcrumbs

### DIFF
--- a/views/collection.html
+++ b/views/collection.html
@@ -34,7 +34,7 @@
     <span class="divider">/</span>
   </li>
   <li>
-    <a href="/db/{{ dbName }}">{{ dbName }}</a>
+    <a href="db/{{ dbName }}">{{ dbName }}</a>
     <span class="divider">/</span>
   </li>
   <li class="active">

--- a/views/document.html
+++ b/views/document.html
@@ -28,11 +28,11 @@
     <span class="divider">/</span>
   </li>
   <li>
-    <a href="/db/{{ dbName }}">{{ dbName }}</a>
+    <a href="db/{{ dbName }}">{{ dbName }}</a>
     <span class="divider">/</span>
   </li>
   <li>
-    <a href="/db/{{ dbName }}/{{ collectionName }}">{{ collectionName }}</a>
+    <a href="db/{{ dbName }}/{{ collectionName }}">{{ collectionName }}</a>
     <span class="divider">/</span>
   </li>
   <li class="active">


### PR DESCRIPTION
The /-prefixed paths break navigation when your baseUrl includes a path beyond root.
