### PR TITLE
filters.js -- to_string does not check for null/undefined inputs

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -19,5 +19,5 @@ exports.convertBytes = function(input) {
 };
 
 exports.to_string = function (input) {
-    return (input !== null && input !== undefined) ? input.toString() : "";
+    return input != null ? input.toString() : "";
 };


### PR DESCRIPTION
The system.indexes collection is created only when the first collection is created in a database. After this collection is created, if you navigate to this collection using mongo-express, it blows up since to_string method does not check for null / undefined. Here is a screenshot with the complete error:

![sys indexes err](https://cloud.githubusercontent.com/assets/1248984/3296081/6d1fe670-f5d2-11e3-8196-4ec7765c9f51.png)

Modification to filters.js in this pull request contains a fix for this!
