### PR TITLE
Added days to uptime info

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -23,7 +23,7 @@
   </tr>
   <tr>
     <td><strong>Uptime</strong></td>
-    <td>{{ info.uptime }} seconds</td>
+    <td>{{ info.uptime }} seconds {% if info.uptime > 86400 %} ({{ Math.floor( info.uptime/86400 ) }} days) {% endif %}</td>
     <td><strong>Server Time</strong></td>
     <td>{{ info.localTime|date('r') }}</td>
   </tr>


### PR DESCRIPTION
Days are shown approximately and only if uptime is longer than a day. Seconds itself wont say much.
