### PR TITLE
Fixing the mountpath based on request.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -61,7 +61,9 @@ var router = function (config) {
   // view helper, sets local variables used in templates
   appRouter.all('*', function (req, res, next) {
     // ensure a trailing slash on the baseHref (used as a prefix in routes and views)
-    res.locals.baseHref       = req.app.mountpath + (req.app.mountpath[req.app.mountpath.length - 1] === '/' ? '' : '/');
+	var mountPathLength       = req.originalUrl.length - req.url.length;
+    var mountPath             = req.originalUrl.slice(0, mountPathLength);
+    res.locals.baseHref       = mountPath + (mountPath[mountPath.length - 1] === '/' ? '' : '/');
     res.locals.databases      = mongo.databases;
     res.locals.collections    = mongo.collections;
     res.locals.gridFSBuckets  = utils.colsToGrid(mongo.collections);


### PR DESCRIPTION
Performing the same mechanism parse-dashboard does to handle being installed as middleware. This fixes #256, in my testing.