### PR TITLE
define mongodb host and port on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Fill in your MongoDB connection details and any other options you want to change
 If you installed it globally, you can immediately start mongo-express like this:
 
     mongo-express -u user -p password -d database
+    
+You can access a remote database by providing MongoDB Host and Port:
+
+    mongo-express -u user -p password -d database -H mongoDBHost -P mongoDBPort
 
 Or if you want to use it as an administrator:
 

--- a/app.js
+++ b/app.js
@@ -47,6 +47,8 @@ if (config.options.console) {
 
 commander
   .version(require('./package').version)
+  .option('-H, --host <host>', 'hostname or adress')
+  .option('-P, --dbport <host>', 'port of the db')
   .option('-u, --username <username>', 'username for authentication')
   .option('-p, --password <password>', 'password for authentication')
   .option('-a, --admin', 'enable authentication as admin')
@@ -76,6 +78,9 @@ if (commander.username && commander.password) {
 
   config.useBasicAuth = false;
 }
+
+config.mongodb.server = commander.host;
+config.mongodb.port = commander.dbport;
 
 config.site.port = commander.port || config.site.port;
 


### PR DESCRIPTION
Allowing the user to define mongoDB Host and Port as argument for the CLI