### PR TITLE
Refreshing collections when viewing database

### DIFF
--- a/lib/routes/database.js
+++ b/lib/routes/database.js
@@ -7,35 +7,43 @@ var routes = function () {
 
   exp.viewDatabase = function (req, res) {
 
-    req.db.stats(function (error, data) {
+    req.updateCollections(req.db, req.dbName, function (error) {
       if (error) {
-        req.session.error = 'Could not get stats. ' + JSON.stringify(error);
+        req.session.error = 'Could not refresh collections. ' + JSON.stringify(error);
         console.error(error);
         return res.redirect('back');
       }
 
-      var ctx = {
-        title: 'Viewing Database: ' + req.dbName,
-        databases:  req.databases,
-        colls:      req.collections[req.dbName],
-        grids:      req.gridFSBuckets[req.dbName],
-        stats: {
-          avgObjSize:         utils.bytesToSize(data.avgObjSize || 0),
-          collections:        data.collections,
-          dataFileVersion:    (data.dataFileVersion && data.dataFileVersion.major && data.dataFileVersion.minor ?
-            data.dataFileVersion.major + '.' + data.dataFileVersion.minor :
-            null),
-          dataSize:           utils.bytesToSize(data.dataSize),
-          extentFreeListNum:  (data.extentFreeList && data.extentFreeList.num ? data.extentFreeList.num : null),
-          fileSize:           (typeof data.fileSize !== 'undefined' ? utils.bytesToSize(data.fileSize) : null),
-          indexes:            data.indexes,
-          indexSize:          utils.bytesToSize(data.indexSize),
-          numExtents:         data.numExtents.toString(),
-          objects:            data.objects,
-          storageSize:        utils.bytesToSize(data.storageSize),
-        },
-      };
-      res.render('database', ctx);
+      req.db.stats(function (error, data) {
+        if (error) {
+          req.session.error = 'Could not get stats. ' + JSON.stringify(error);
+          console.error(error);
+          return res.redirect('back');
+        }
+
+        var ctx = {
+          title: 'Viewing Database: ' + req.dbName,
+          databases:  req.databases,
+          colls:      req.collections[req.dbName],
+          grids:      req.gridFSBuckets[req.dbName],
+          stats: {
+            avgObjSize:         utils.bytesToSize(data.avgObjSize || 0),
+            collections:        data.collections,
+            dataFileVersion:    (data.dataFileVersion && data.dataFileVersion.major && data.dataFileVersion.minor ?
+              data.dataFileVersion.major + '.' + data.dataFileVersion.minor :
+              null),
+            dataSize:           utils.bytesToSize(data.dataSize),
+            extentFreeListNum:  (data.extentFreeList && data.extentFreeList.num ? data.extentFreeList.num : null),
+            fileSize:           (typeof data.fileSize !== 'undefined' ? utils.bytesToSize(data.fileSize) : null),
+            indexes:            data.indexes,
+            indexSize:          utils.bytesToSize(data.indexSize),
+            numExtents:         data.numExtents.toString(),
+            objects:            data.objects,
+            storageSize:        utils.bytesToSize(data.storageSize),
+          },
+        };
+        res.render('database', ctx);
+      });
     });
   };
 


### PR DESCRIPTION
I noticed that if new collections are added after launching the app, they actually never appear on the interface because we never refresh the list. This quick fix forces refreshing the collections list when accessing the page.