### PR TITLE
use config.mongodb.{server|port} if commander.{host|dbport} are falsy

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,8 +79,8 @@ if (commander.username && commander.password) {
   config.useBasicAuth = false;
 }
 
-config.mongodb.server = commander.host;
-config.mongodb.port = commander.dbport;
+config.mongodb.server = commander.host || config.mongodb.server;
+config.mongodb.port = commander.dbport || config.mongodb.port;
 
 config.site.port = commander.port || config.site.port;
 


### PR DESCRIPTION
Fixes #266 (the issue shows the problem and steps to reproduce).

Currently config.mongodb.server and config.mongodb.port are replaced
unconditionally with commander.host and commander.dbport.
They get set to undefined if the command line arguments are missing.

This change keeps the config.mongodb.* values if the command line
arguments are falsy, which is how config.site.port is already handled.