### PR TITLE
Fix incorrect stringification of ObjectID

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -200,7 +200,7 @@ var routes = function (config) {
             last: last,
             pagination: pagination,
             key: key,
-            value: value,
+            value: type === 'O' ? ['ObjectID("',value,'")'].join('') : value,
             type: type,
             query: jsonQuery,
             projection: jsonProjection,


### PR DESCRIPTION
### Cause
ObjectID got stringified into [Object object]. When this value is used in `lib/views/collection.html`, it produces incorrect url (example `http://node.i4kafra.com:8081/db/emdb/users?skip=0&key=schools_id&value=[Object object]&type=O&query=&projection=`}.

### Steps to Repeat
1. go to a collection
2. search the collection by ObjectID
3. Once the search is completed, press the button `Next` or `Last`
4. The UI shows error "ObjectID(...) wrapper must be present" and the page won't proceed to the next page as expected
