### PR TITLE
feature: delete all documents matching a query

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -9,6 +9,83 @@ var csv   = require('../csv');
 var routes = function (config) {
   var exp = {};
 
+  /*
+   * Builds the Mongo query corresponding to the
+   * Simple/Advanced parameters input.
+   * Returns null if no query parameters were passed in request.
+   */
+  exp._buildMongoQuery = function (req) {
+    var result = null;
+    var key = req.query.key;
+    var value = req.query.value;
+    var type = req.query.type && req.query.type.toUpperCase();
+    var jsonQuery = req.query.query;
+
+    if (key && value) {
+      // if it is a simple query,
+
+      // 1. fist convert value to its actual type
+      var converters = {
+        // If type == J, convert value as json document
+        J: function (value) {
+          return JSON.parse(value);
+        },
+        // If type == N, convert value to number
+        N: function (value) {
+          return Number(value);
+        },
+        // If type == O, convert value to ObjectID
+        O: function (value) {
+          // Hex input
+          var result = bson.hexToObjectId(value);
+
+          if (!result) {
+            // Basic validation
+            // Check we have ObjectID() wrapper
+            if (
+              value.toUpperCase().indexOf('OBJECTID(') === -1 ||   // missing the opening 'ObjectID('
+              value.indexOf(')') === -1                            // missing the closing '('
+            ) {
+              throw new Error('ObjectID(...) wrapper must be present');
+              // req.session.error = 'ObjectID(...) wrapper must be present';
+              // return res.redirect('back');
+            }
+
+            result = bson.toObjectId(value);
+            if (!value) {
+              throw new Error('ObjectID is invalid');
+            }
+          }
+          return result;
+        },
+        // If type == R, convert to RegExp
+        R: function (value) {
+          return new RegExp(value, 'i');
+        },
+        // if type == S, no conversion done
+        S: function (value) {
+          return value;
+        },
+      };
+      if (!converters[type]) {
+        throw new Error('Invalid query type: ' + type);
+      }
+      value = converters[type](value);
+
+      // 2. then set query to it
+      result = {};
+      result[key] = value;
+    } else if (jsonQuery) {
+      // if it is a complex query, take it as is;
+      result = bson.toSafeBSON(jsonQuery);
+      if (result === null) {
+        throw new Error('Query entered is not valid');
+      }
+    }
+    // otherwise leave as null;
+    return result;
+  };
+
   //view all entries in a collection
   exp.viewCollection = function (req, res) {
 
@@ -28,14 +105,22 @@ var routes = function (config) {
       skip:   skip,
     };
 
-    // some query filter
-    var query           = {};
+    var query;
+    try {
+      // if no criteria were passed, return whole list
+      query = exp._buildMongoQuery(req, res) || {};
+    } catch (err) {
+      req.session.error = err.message;
+      return res.redirect('back');
+    }
+
     var projection      = {};
-    var key             = req.query.key         || '';
-    var value           = req.query.value       || '';
-    var type            = req.query.type        || '';
-    var jsonQuery       = req.query.query       || '';
     var jsonProjection  = req.query.projection  || '';
+    if (jsonProjection) {
+      projection = bson.toSafeBSON(jsonProjection) || {};
+    }
+
+    // determine default key
     var dbName          = req.params.database;
     var collectionName  = req.params.collection;
     var defaultKey = (config.defaultKeyNames && config.defaultKeyNames[dbName] && config.defaultKeyNames[dbName][collectionName]) ?
@@ -49,72 +134,13 @@ var routes = function (config) {
           val = val[defaultKeyAsArray[i]];
         }
       }
-
       return val;
     };
-
-    if (key && value) {
-      // If type == J, convert value as json document
-      if (type.toUpperCase() === 'J') {
-        value = JSON.parse(req.query.value);
-      }
-
-      // If type == N, convert value to Number
-      if (type.toUpperCase() === 'N') {
-        value = Number(req.query.value);
-      }
-
-      // If type == O, convert value to ObjectID
-      // TODO: Add ObjectID validation to prevent error messages.
-      if (type.toUpperCase() === 'O') {
-
-        // Hex input
-        value = bson.hexToObjectId(req.query.value);
-
-        if (!value) {
-          // Basic validation
-          // Check we have ObjectID() wrapper
-          if (
-            req.query.value.toUpperCase().indexOf('OBJECTID(') === -1 ||   // missing the opening 'ObjectID('
-            req.query.value.indexOf(')') === -1                            // missing the closing '('
-          ) {
-            req.session.error = 'ObjectID(...) wrapper must be present';
-            return res.redirect('back');
-          }
-
-          value = bson.toObjectId(req.query.value);
-          if (!value) {
-            req.session.error = 'ObjectID is invalid';
-            return res.redirect('back');
-          }
-        }
-      }
-
-      if (type.toUpperCase() === 'R') {
-        query[key] = new RegExp(req.query.value, 'i');
-      } else {
-        query[key] = value;
-      }
-
-    } else if (jsonQuery) {
-      query = bson.toSafeBSON(jsonQuery);
-      if (query === null) {
-        req.session.error = 'Query entered is not valid';
-        return res.redirect('back');
-      }
-
-      if (jsonProjection) {
-        projection = bson.toSafeBSON(jsonProjection) || {};
-      }
-    } else {
-      query = {};
-    }
 
     req.collection.find(query, projection, query_options).toArray(function (err, items) {
       req.collection.stats(function (err, stats) {
         req.collection.indexes(function (err, indexes) {
           req.collection.count(query, null, function (err, count) {
-
             //Pagination
             //Have to do this here, swig template doesn't allow any calculations :(
             var prev;
@@ -201,6 +227,7 @@ var routes = function (config) {
               documents: items, // Docs converted to strings
               docs: docs,       // Original docs
               columns: columns, // All used columns
+              count: count, // total number of docs returned by the query
               stats: stats,
               editorTheme: config.options.editorTheme,
               limit: limit,
@@ -213,10 +240,11 @@ var routes = function (config) {
               here: here,
               last: last,
               pagination: pagination,
-              key: key,
-              value: type === 'O' ? ['ObjectID("', value, '")'].join('') : value,
-              type: type,
-              query: jsonQuery,
+              key: req.query.key,
+              value: req.query.value,
+              // value: type === 'O' ? ['ObjectID("', value, '")'].join('') : value,
+              type: req.query.type,
+              query: req.query.query,
               projection: jsonProjection,
               defaultKey: defaultKey,
               edKey: edKey,
@@ -318,26 +346,38 @@ var routes = function (config) {
   };
 
   exp.deleteCollection = function (req, res) {
-    req.collection.drop(function (err) {
-      if (err) {
-        req.session.error = 'Something went wrong: ' + err;
-        console.error(err);
-        return res.redirect('back');
-      }
-
-      //If delete was successful, result === true
-
-      req.updateCollections(req.db, req.dbName, function (err) {
+    var query = exp._buildMongoQuery(req);
+    if (query) {
+      // we're just deleting some of the documents
+      var deleteOptions = null;
+      req.collection.deleteMany(query, deleteOptions, function (err, opRes) {
         if (err) {
           req.session.error = 'Something went wrong: ' + err;
           console.error(err);
           return res.redirect('back');
         }
-
-        req.session.success = 'Collection  "' + req.collectionName + '" deleted!';
-        res.redirect(res.locals.baseHref + 'db/' + req.dbName);
+        req.session.success = opRes.result.n + ' documents deleted from "' + req.collectionName + '"';
+        res.redirect(res.locals.baseHref + 'db/' + req.dbName + '/' + req.collectionName);
       });
-    });
+    } else {
+      // no query means we're dropping the whole collection
+      req.collection.drop(function (err) {
+        if (err) {
+          req.session.error = 'Something went wrong: ' + err;
+          console.error(err);
+          return res.redirect('back');
+        }
+        req.updateCollections(req.db, req.dbName, function (err) {
+          if (err) {
+            req.session.error = 'Something went wrong: ' + err;
+            console.error(err);
+            return res.redirect('back');
+          }
+          req.session.success = 'Collection  "' + req.collectionName + '" deleted!';
+          res.redirect(res.locals.baseHref + 'db/' + req.dbName);
+        });
+      });
+    }
   };
 
   exp.renameCollection = function (req, res) {

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -159,6 +159,18 @@ jQuery(document).ready(function ($) {
       </form>
     </div>
   </div>
+  {% if !settings.read_only && count > 0 %}
+  <p>
+    <form id="deleteListForm" method="POST" style="display:inline;" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}">
+      {# Router is smart enough to transform method=POST + _method=delete into actual HTTP DELETE, which is what we want #}
+      <input type="hidden" name="_method" value="delete">
+      <button type="button" data-toggle="modal" data-target="#deleteListModal" class="btn btn-danger btn-large btn-block">
+        <span class="glyphicon glyphicon-trash"></span>
+        Delete all {{count}} documents retrieved
+      </button>
+    </form>
+  </p>
+  {% endif %}
   <br/>
 
 <!-- Add Document Modal -->
@@ -511,6 +523,15 @@ $(document).ready(function () {
     }
   );
 
+  $('#deleteListConfirmButton').on('click', function (e) {
+    console.log('deleteList', e);
+//    e.stopPropagation();
+//    e.preventDefault();
+    // we just need to POST the form, as all the query parameters are already embedded in it
+    $('#deleteListForm').trigger('submit');
+    }
+  );
+
   $('.deleteButtonCollection').on('click', function (event) {
 
     $('.deleteButtonCollection').tooltip('hide');
@@ -562,6 +583,20 @@ $(document).ready(function () {
             </div>
             <div class="modal-footer">
               <button type="button" data-dismiss="modal" class="btn btn-danger" id="delete">Delete</button>
+              <button type="button" data-dismiss="modal" class="btn">Cancel</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="deleteListModal" class="modal fade" role="dialog" aria-labelledby="confirmDeletionListLabel">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-body">
+              Are you sure you want to delete all {{count}} documents?
+            </div>
+            <div class="modal-footer">
+              <button type="button" data-dismiss="modal" class="btn btn-danger" id="deleteListConfirmButton">Delete</button>
               <button type="button" data-dismiss="modal" class="btn">Cancel</button>
             </div>
           </div>

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -510,27 +510,19 @@ $(document).ready(function () {
   });
 
   $('.deleteButtonDocument').on('click', function (e) {
-    console.log(this, e);
-      var $form = $(this).closest('form');
-      console.log($form);
-      e.stopPropagation();
-      e.preventDefault();
+    var $form = $(this).closest('form');
+    e.stopPropagation();
+    e.preventDefault();
 
-      $('#confirm-deletion-document').modal({ backdrop: 'static', keyboard: false })
-        .one('click', '#delete', function () {
-          $form.trigger('submit'); // submit the form
-        });
-    }
-  );
+    $('#confirm-deletion-document').modal({ backdrop: 'static', keyboard: false }).one('click', '#delete', function () {
+      $form.trigger('submit'); // submit the form
+    });
+  });
 
   $('#deleteListConfirmButton').on('click', function (e) {
-    console.log('deleteList', e);
-//    e.stopPropagation();
-//    e.preventDefault();
-    // we just need to POST the form, as all the query parameters are already embedded in it
+    // we just need to POST the form, as all the query parameters are already embedded in the form action
     $('#deleteListForm').trigger('submit');
-    }
-  );
+  });
 
   $('.deleteButtonCollection').on('click', function (event) {
 


### PR DESCRIPTION
Hi,

I needed the ability to delete a hundred documents returned by a query. Not the whole collection, but too much to do it one by one.

So this PR adds a "Delete" button under the query form of the collections view that lets users delete the documents based on the query they input.

From a technical point of view, I did:

- extract the query building part of viewCollection so that both methods use the same code.
- hook into DELETE /db/collection and deletes if there is a query, drops if there isn't
- add a 'count' property to the rendering contrext, with the total number of documents returned by the query

Let me know if you need anything else to merge it.