### PR TITLE
Don't enter in edit mode with selection

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -424,7 +424,9 @@ renderjson.set_show_to_level({{ collapsibleJSONDefaultUnfold }});
 <script type="text/javascript">
 
 function loadDocument(id) {
-  location.href = '{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/' + encodeURIComponent(id);
+  if( window.getSelection() == "" ) {
+    location.href = '{{ baseHref }}db/{{ dbName }}/{{ collectionName }}/' + encodeURIComponent(id);
+  }
 }
 
 $(document).ready(function () {


### PR DESCRIPTION
Into Collection page are listed all documents, if there is a mouse selection (for copy-paste a string) then mongo-express don't enter in Edit Mode for Document.