### PR TITLE
Fix options not working in middleware-only usage

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,9 +93,6 @@ if (!config.site.baseUrl) {
 app.use(config.site.baseUrl, middleware(config));
 app.use(csrf());
 
-app.set('read_only',      config.options.readOnly       || false);
-app.set('gridFSEnabled',  config.options.gridFSEnabled  || false);
-
 if (config.site.sslEnabled) {
   defaultPort     = 443;
   sslOptions  = {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -22,6 +22,9 @@ var middleware = function (config) {
 
   app.use('/', router(config));
 
+  app.set('read_only',      config.options.readOnly      || false);
+  app.set('gridFSEnabled',  config.options.gridFSEnabled || false);
+
   return app;
 };
 


### PR DESCRIPTION
Config options `readOnly` and `gridFSEnabled` does not work properly if only use the middleware (e.g. in other app).