### PR TITLE
Add config.options.logger to control logging

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -148,6 +148,9 @@ module.exports = {
 
     //gridFSEnabled: if gridFSEnabled is set to 'true', you will be able to manage uploaded files ( ak. grids, gridFS )
     gridFSEnabled: false,
+
+    // logger: this object will be used to initialize router logger (morgan)
+    logger: {},
   },
 
   // Specify the default keyname that should be picked from a document to display in collections list.

--- a/lib/router.js
+++ b/lib/router.js
@@ -26,7 +26,7 @@ var router = function (config) {
 
   appRouter.use(favicon(__dirname + '/../public/images/favicon.ico'));
 
-  appRouter.use(logger('dev'));
+  appRouter.use(logger('dev', config.options.logger));
 
   appRouter.use('/', express.static(__dirname + '/../public'));
 


### PR DESCRIPTION
Useful if middleware is in other app which already has logging at the app level.