### PR TITLE
Fix content-disposition for non-ascii header, set config.gridFSEnabled via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Fill in your MongoDB connection details and any other options you want to change
 If you installed it globally, you can immediately start mongo-express like this:
 
     mongo-express -u user -p password -d database
-    
+
 You can access a remote database by providing MongoDB Host and Port:
 
     mongo-express -u user -p password -d database -H mongoDBHost -P mongoDBPort
@@ -135,6 +135,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
     `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.
     `ME_CONFIG_SITE_SSL_KEY_PATH`     | ` `             | SSL key file.
+    `ME_CONFIG_SITE_GRIDFS_ENABLED`   | `false`         | Enable gridFS to manage uploaded files.
 
 **Example:**
 

--- a/config.default.js
+++ b/config.default.js
@@ -147,7 +147,7 @@ module.exports = {
     collapsibleJSONDefaultUnfold: 1,
 
     //gridFSEnabled: if gridFSEnabled is set to 'true', you will be able to manage uploaded files ( ak. grids, gridFS )
-    gridFSEnabled: false,
+    gridFSEnabled: process.env.ME_CONFIG_SITE_GRIDFS_ENABLED || false,
 
     // logger: this object will be used to initialize router logger (morgan)
     logger: {},

--- a/lib/routes/gridfs.js
+++ b/lib/routes/gridfs.js
@@ -106,7 +106,7 @@ var routes = function () {
       }
 
       res.set('Content-Type', file.contentType);
-      res.set('Content-Disposition', 'attachment; filename="' + file.filename + '"');
+      res.set('Content-Disposition', 'attachment; filename="' + encodeURI(file.filename) + '"');
 
       var readstream = gfs.createReadStream({
         _id: file._id,


### PR DESCRIPTION
1. Non-ascii symbols aren't allowed in setHeaders in Node 5+
So, if I have cyrillic filename for example, it will brake everything.
Similar issue: https://github.com/nodejs/node/issues/1693

2. It's very useful to be able to set config.gridFSEnabled via env vars, when using Docker.