### PR TITLE
[Fixes #319] Fix router baseHref

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -58,12 +58,23 @@ var router = function (config) {
     appRouter.use(errorHandler());
   }
 
+  var buildBaseHref = function (originalUrl, reqUrl) {
+    var addTrailingSlash = function (s) {
+      return s + (s[s.length - 1] === '/' ? '' : '/');
+    };
+
+    if (reqUrl === '/') {
+      return addTrailingSlash(originalUrl);
+    }
+
+    var idx = originalUrl.lastIndexOf(reqUrl);
+    var root = originalUrl.substring(0, idx);
+    return addTrailingSlash(root);
+  };
+
   // view helper, sets local variables used in templates
   appRouter.all('*', function (req, res, next) {
-    // ensure a trailing slash on the baseHref (used as a prefix in routes and views)
-    var mountPathLength       = req.originalUrl.length - req.url.length;
-    var mountPath             = req.originalUrl.slice(0, mountPathLength);
-    res.locals.baseHref       = mountPath + (mountPath[mountPath.length - 1] === '/' ? '' : '/');
+    res.locals.baseHref       = buildBaseHref(req.originalUrl, req.url);
     res.locals.databases      = mongo.databases;
     res.locals.collections    = mongo.collections;
     res.locals.gridFSBuckets  = utils.colsToGrid(mongo.collections);


### PR DESCRIPTION
Hopefully this works. I tested both running from the command line, and running in my app which uses mongo-express as middleware routed to various urls. If you have a more in-depth regression test process, I would definitely try that :)

To solve it, I started out by printing the `req.originalUrl` and `req.url` while navigating through the app, and looking at how to transform those values into a base url that would work for all of them. My test data essentially looked like this:

```js
buildBaseHref('/myRoutes/foo', '/');
buildBaseHref('/myRoutes/foo/db/FH_LOCAL/', '/db/FH_LOCAL/');
buildBaseHref('/myRoutes/foo/db/FH_LOCAL/public/css/bootstrap-theme.min.css', '/db/FH_LOCAL/public/css/bootstrap-theme.min.css');
buildBaseHref('/myRoutes/foo/db/FH_LOCAL/public/img/gears.gif/db/FH_LOCAL', '/db/FH_LOCAL/public/img/gears.gif/db/FH_LOCAL');
```

In every case, the returned value should be `/myRoutes/foo/`, which is what the buildBaseHref() function does, by removing the req.url from the end of the req.originalUrl. (Unless it's the base route, which is unfortunately a special case.) Hooray for TDD.

Let me know if I missed something. I likely did.