### PR TITLE
Use stream for exporting collections

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -288,18 +288,13 @@ var routes = function (config) {
   };
 
   exp.exportCollection = function (req, res) {
-    req.collection.find().toArray(function (err, items) {
-      res.setHeader('Content-disposition', 'attachment; filename=' + req.collectionName + '.json');
-      res.setHeader('Content-type', 'application/json');
-      var aItems = [];
-      for (var i in items) {
-        var docStr = bson.toJsonString(items[i]);
-        aItems.push(docStr);
-      }
-
-      res.write(aItems.join(os.EOL));
-      res.end();
-    });
+    res.setHeader('Content-disposition', 'attachment; filename=' + req.collectionName + '.json');
+    res.setHeader('Content-type', 'application/json');
+    req.collection.find().stream({
+      transform: function (item) {
+        return bson.toJsonString(item) + os.EOL;
+      },
+    }).pipe(res);
   };
 
   exp.exportColArray = function (req, res) {


### PR DESCRIPTION
User can't export big collections.

Cause: toArray function loads all documents in memory. If server ram didn't fit, mongo-express will exist.