### PR TITLE
Support for connection strings so this works easily with atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     ----------------------------------|-----------------|------------
     `ME_CONFIG_MONGODB_SERVER`        |`mongo` or `localhost`| MongoDB host name or IP address. The default is `localhost` in the config file and `mongo` in the docker image. If it is a replica set, use a comma delimited list of the host names.
     `ME_CONFIG_MONGODB_PORT`          | `27017`         | MongoDB port.
+    `ME_CONFIG_MONGODB_URL`           | `mongodb://admin:pass@localhost:27017/db?ssl=false`
     `ME_CONFIG_MONGODB_ENABLE_ADMIN`  | `false`         | Enable administrator access. Send strings: `"true"` or `"false"`.
     `ME_CONFIG_MONGODB_ADMINUSERNAME` | ` `             | Administrator username.
     `ME_CONFIG_MONGODB_ADMINPASSWORD` | ` `             | Administrator password.

--- a/app.js
+++ b/app.js
@@ -81,7 +81,7 @@ if (commander.username && commander.password) {
   config.useBasicAuth = false;
 }
 
-if(commander.url) {
+if (commander.url) {
   config.mongodb.connectionString = commander.url;
   if (commander.admin) {
     config.mongodb.admin = true;

--- a/app.js
+++ b/app.js
@@ -48,6 +48,7 @@ if (config.options.console) {
 
 commander
   .version(require('./package').version)
+  .option('-U, --url <url>', 'connection string url')
   .option('-H, --host <host>', 'hostname or adress')
   .option('-P, --dbport <host>', 'port of the db')
   .option('-u, --username <username>', 'username for authentication')
@@ -78,6 +79,13 @@ if (commander.username && commander.password) {
   }
 
   config.useBasicAuth = false;
+}
+
+if(commander.url) {
+  config.mongodb.connectionString = commander.url;
+  if (commander.admin) {
+    config.mongodb.admin = true;
+  }
 }
 
 config.mongodb.server = commander.host || config.mongodb.server;

--- a/config.default.js
+++ b/config.default.js
@@ -1,13 +1,6 @@
 'use strict';
 
 var mongo;
-var url = require('url');
-
-if (typeof process.env.MONGODB_PORT === 'string') {
-  var mongoConnection = url.parse(process.env.MONGODB_PORT);
-  process.env.ME_CONFIG_MONGODB_SERVER  = mongoConnection.hostname;
-  process.env.ME_CONFIG_MONGODB_PORT    = mongoConnection.port;
-}
 
 // Accesing Bluemix variable to get MongoDB info
 if (process.env.VCAP_SERVICES) {
@@ -18,13 +11,9 @@ if (process.env.VCAP_SERVICES) {
   }
 } else {
   mongo = {
-    db:       'db',
-    host:     'localhost',
-    password: 'pass',
-    port:     27017,
-    ssl:      false,
-    url:      'mongodb://localhost:27017/db',
-    username: 'admin',
+    // setting the connection string will only give access to that database
+    // to see more databases you need to set mongodb.admin to true or add databases to the mongodb.auth list
+    connectionString: process.env.ME_CONFIG_MONGODB_SERVER ? '' : process.env.ME_CONFIG_MONGODB_URL || 'mongodb://admin:pass@localhost:27017/db?ssl=false',
   };
 }
 
@@ -32,6 +21,9 @@ var meConfigMongodbServer = process.env.ME_CONFIG_MONGODB_SERVER ? process.env.M
 
 module.exports = {
   mongodb: {
+    // if a connection string options such as server/port/etc are ignored
+    connectionString: mongo.connectionString,
+
     //server: mongodb hostname or IP address
     //for replica set, use array of string instead
     server: (meConfigMongodbServer.length > 1 ? meConfigMongodbServer : meConfigMongodbServer[0]) || mongo.host,

--- a/config.default.js
+++ b/config.default.js
@@ -2,6 +2,8 @@
 
 var mongo;
 
+const defaultConnectionString = 'mongodb://admin:pass@localhost:27017/db?ssl=false';
+
 // Accesing Bluemix variable to get MongoDB info
 if (process.env.VCAP_SERVICES) {
   var dbLabel = 'mongodb-2.4';
@@ -13,7 +15,7 @@ if (process.env.VCAP_SERVICES) {
   mongo = {
     // setting the connection string will only give access to that database
     // to see more databases you need to set mongodb.admin to true or add databases to the mongodb.auth list
-    connectionString: process.env.ME_CONFIG_MONGODB_SERVER ? '' : process.env.ME_CONFIG_MONGODB_URL || 'mongodb://admin:pass@localhost:27017/db?ssl=false',
+    connectionString: process.env.ME_CONFIG_MONGODB_SERVER ? '' : process.env.ME_CONFIG_MONGODB_URL || defaultConnectionString,
   };
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,14 +5,17 @@ const async = require('async');
 const mongodb = require('mongodb');
 
 let connect = function (config) {
-  // set up database stuff
-  let host = config.mongodb.server  || 'localhost';
-  let port = config.mongodb.port    || mongodb.Connection.DEFAULT_PORT;
-
-  if (config.mongodb.useSSL) {
-    console.error('Please update config file to use mongodb.ssl instead of mongodb.useSSL. Copying value for now.');
-    config.mongodb.ssl = config.mongodb.useSSL;
-  }
+  // connectionData is what gets passed back from this method and used
+  // some fields will not be populated until a connection is established
+  let connectionData = {
+    // adminDb:            undefined,
+    // mainConn:           undefined,
+    collections:        [],
+    connections:        [],
+    databases:          [],
+    updateCollections:  updateCollections,
+    updateDatabases:    updateDatabases,
+  };
 
   let dbOptions = {
     auto_reconnect: config.mongodb.autoReconnect,
@@ -22,27 +25,38 @@ let connect = function (config) {
     sslCA:          config.mongodb.sslCA,
   };
 
-  let db;
+  // database connection
+  if(config.mongodb.connectionString) {
+	  mongodb.MongoClient.connect(config.mongodb.connectionString, dbOptions, processOpenDatabase);
+  }
+  else {
+    // set up database using legacy configuration
+    let host = config.mongodb.server  || 'localhost';
+    let port = config.mongodb.port    || mongodb.Connection.DEFAULT_PORT;
 
-  if (Array.isArray(host)) {
-    host = host.map(function (host) {
-      return new mongodb.Server(host, port, dbOptions);
-    });
+    if (config.mongodb.useSSL) {
+      console.error('Please update config file to use mongodb.ssl instead of mongodb.useSSL. Copying value for now.');
+      config.mongodb.ssl = config.mongodb.useSSL;
+    }
 
-    db = new mongodb.Db('local', new mongodb.ReplSet(host), { safe: true, w: 0 });
-  } else {
-    db = new mongodb.Db('local', new mongodb.Server(host, port, dbOptions), { safe: true });
+    let db;
+
+    if (Array.isArray(host)) {
+      host = host.map(function (host) {
+        return new mongodb.Server(host, port, dbOptions);
+      });
+
+      db = new mongodb.Db('local', new mongodb.ReplSet(host), { safe: true, w: 0 });
+      db.open(processOpenDatabase);
+    }
+    else  {
+      db = new mongodb.Db('local', new mongodb.Server(host, port, dbOptions), { safe: true });
+      db.open(processOpenDatabase);
+    }
   }
 
-  let collections     = {};
-  let connections     = {};
-  let databases       = [];
-
-  let adminDb = db.admin();
-  let mainConn  = db; // main db connection
-
   // update the collections list
-  let updateCollections = function (db, dbName, callback) {
+  function updateCollections(db, dbName, callback) {
     db.listCollections().toArray(function (err, result) {
       let names = [];
 
@@ -50,7 +64,7 @@ let connect = function (config) {
         names.push(result[r].name);
       }
 
-      collections[dbName] = names.sort();
+      connectionData.collections[dbName] = names.sort();
 
       if (callback) {
         callback(err);
@@ -59,61 +73,70 @@ let connect = function (config) {
   };
 
   // update database list
-  let updateDatabases = function (admin, callback) {
+  function updateDatabases(admin, callback) {
+
+    if(!admin) {
+      console.error('Admin database is not accessable');
+    }
 
     admin.listDatabases(function (err, dbs) {
-      databases = [];
+      connectionData.databases = [];
+
       if (err) {
         //TODO: handle error
+        console.error('unable to list databases');
         console.error(err);
-        databases = _.map(config.mongodb.auth, 'database');
+        connectionData.databases = _.map(config.mongodb.auth, 'database');
       } else {
         for (let i = 0; i < dbs.databases.length; i++) {
           let dbName = dbs.databases[i].name;
-
-          if (config.mongodb.whitelist.length !== 0) {
-            if (!_.includes(config.mongodb.whitelist, dbName)) {
-              continue;
+          if(dbName) {
+            if (config.mongodb.whitelist.length !== 0) {
+              if (!_.includes(config.mongodb.whitelist, dbName)) {
+                continue;
+              }
             }
-          }
 
-          if (config.mongodb.blacklist.length !== 0) {
-            if (_.includes(config.mongodb.blacklist, dbName)) {
-              continue;
+            if (config.mongodb.blacklist.length !== 0) {
+              if (_.includes(config.mongodb.blacklist, dbName)) {
+                continue;
+              }
             }
-          }
 
-          connections[dbName] = mainConn.db(dbName);
-          databases.push(dbName);
-          updateCollections(connections[dbName], dbName);
+            connectionData.connections[dbName] = connectionData.mainConn.db(dbName);
+            connectionData.databases.push(dbName);
+            connectionData.updateCollections(connectionData.connections[dbName], dbName);
+          }
         }
       }
 
       //Sort database names
-      databases = databases.sort();
+      connectionData.databases = connectionData.databases.sort();
 
       if (callback) {
-        callback(databases);
+        callback(connectionData.databases);
       }
     });
   };
 
   // connect to mongodb database
-  db.open(function (err, db) {
+  function processOpenDatabase(err, db) {
     if (err) {
       throw err;
     }
 
     if (config.options.console) console.log('Database connected');
-
-    mainConn = db;
+	
+	  connectionData.mainConn = db;
 
     //Check if admin features are on
     if (config.mongodb.admin === true) {
+	    let adminDb = db.admin();
+      connectionData.adminDb = adminDb;
 
-      if (config.mongodb.adminUsername.length === 0) {
+      if (!config.mongodb.adminUsername || config.mongodb.adminUsername.length === 0) {
         if (config.options.console) console.log('Admin Database connected');
-        updateDatabases(adminDb);
+        connectionData.updateDatabases(adminDb);
       } else {
         //auth details were supplied, authenticate admin account with them
         adminDb.authenticate(config.mongodb.adminUsername, config.mongodb.adminPassword, function (err) {
@@ -123,53 +146,53 @@ let connect = function (config) {
           }
 
           if (config.options.console) console.log('Admin Database connected');
-          updateDatabases(adminDb);
+          connectionData.updateDatabases(adminDb);
         });
       }
     } else {
       //Regular user authentication
-      if (typeof config.mongodb.auth === 'undefined' || config.mongodb.auth.length === 0) {
-        throw new Error('Add auth details to config or turn on admin!');
+      if (typeof config.mongodb.auth === 'undefined' || config.mongodb.auth.length === 0 || !config.mongodb.auth[0].database) {
+        // no auth list specified so use the database from the connection string
+        var currentDbName = db.databaseName;
+        if (config.options.console) console.log('Connected to ' + currentDbName + '...');
+        connectionData.connections[currentDbName] = db;
+        connectionData.databases.push(currentDbName);
+        connectionData.updateCollections(db, currentDbName);
       }
+      else {
+        async.forEachSeries(config.mongodb.auth, function (auth, callback) {
+          if(auth.database) {
+            if (config.options.console) console.log('Connecting to ' + auth.database + '...');
+            connectionData.connections[auth.database] = connectionData.mainConn.db(auth.database);
+            connectionData.databases.push(auth.database);
 
-      async.forEachSeries(config.mongodb.auth, function (auth, callback) {
-        if (config.options.console) console.log('Connecting to ' + auth.database + '...');
-        connections[auth.database] = mainConn.db(auth.database);
-        databases.push(auth.database);
+            if (typeof auth.username !== 'undefined' && auth.username.length !== 0) {
+              connectionData.connections[auth.database].authenticate(auth.username, auth.password, function (err, success) {
+                if (err) {
+                  //TODO: handle error
+                  console.error(err);
+                }
 
-        if (typeof auth.username !== 'undefined' && auth.username.length !== 0) {
-          connections[auth.database].authenticate(auth.username, auth.password, function (err, success) {
-            if (err) {
-              //TODO: handle error
-              console.error(err);
+                if (!success) {
+                  console.error('Could not authenticate to database "' + auth.database + '"');
+                }
+
+                connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
+                if (config.options.console) console.log('Database ' + auth.database + ' connected');
+                callback();
+              });
+            } else {
+              connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
+              if (config.options.console) console.log('Database ' + auth.database + ' connected');
+              callback();
             }
-
-            if (!success) {
-              console.error('Could not authenticate to database "' + auth.database + '"');
-            }
-
-            updateCollections(connections[auth.database], auth.database);
-            if (config.options.console) console.log('Database ' + auth.database + ' connected');
-            callback();
-          });
-        } else {
-          updateCollections(connections[auth.database], auth.database);
-          if (config.options.console) console.log('Database ' + auth.database + ' connected');
-          callback();
-        }
-      });
+          }
+        });
+      }
     }
-  });
+  }
 
-  return {
-    adminDb:            adminDb,
-    collections:        collections,
-    connections:        connections,
-    databases:          databases,
-    mainConn:           mainConn,
-    updateCollections:  updateCollections,
-    updateDatabases:    updateDatabases,
-  };
+  return connectionData;
 };
 
 module.exports = connect;

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,7 +5,7 @@ const async = require('async');
 const mongodb = require('mongodb');
 
 let connect = function (config) {
-  // connectionData is what gets passed back from this method and used
+  // connectionData gets passed back from this method
   // some fields will not be populated until a connection is established
   let connectionData = {
     // adminDb:            undefined,
@@ -13,50 +13,10 @@ let connect = function (config) {
     collections:        [],
     connections:        [],
     databases:          [],
-    updateCollections:  updateCollections,
-    updateDatabases:    updateDatabases,
   };
-
-  let dbOptions = {
-    auto_reconnect: config.mongodb.autoReconnect,
-    poolSize:       config.mongodb.poolSize,
-    ssl:            config.mongodb.ssl,
-    sslValidate:    config.mongodb.sslValidate,
-    sslCA:          config.mongodb.sslCA,
-  };
-
-  // database connection
-  if(config.mongodb.connectionString) {
-	  mongodb.MongoClient.connect(config.mongodb.connectionString, dbOptions, processOpenDatabase);
-  }
-  else {
-    // set up database using legacy configuration
-    let host = config.mongodb.server  || 'localhost';
-    let port = config.mongodb.port    || mongodb.Connection.DEFAULT_PORT;
-
-    if (config.mongodb.useSSL) {
-      console.error('Please update config file to use mongodb.ssl instead of mongodb.useSSL. Copying value for now.');
-      config.mongodb.ssl = config.mongodb.useSSL;
-    }
-
-    let db;
-
-    if (Array.isArray(host)) {
-      host = host.map(function (host) {
-        return new mongodb.Server(host, port, dbOptions);
-      });
-
-      db = new mongodb.Db('local', new mongodb.ReplSet(host), { safe: true, w: 0 });
-      db.open(processOpenDatabase);
-    }
-    else  {
-      db = new mongodb.Db('local', new mongodb.Server(host, port, dbOptions), { safe: true });
-      db.open(processOpenDatabase);
-    }
-  }
 
   // update the collections list
-  function updateCollections(db, dbName, callback) {
+  connectionData.updateCollections = function (db, dbName, callback) {
     db.listCollections().toArray(function (err, result) {
       let names = [];
 
@@ -73,9 +33,9 @@ let connect = function (config) {
   };
 
   // update database list
-  function updateDatabases(admin, callback) {
+  connectionData.updateDatabases = function (admin, callback) {
 
-    if(!admin) {
+    if (!admin) {
       console.error('Admin database is not accessable');
     }
 
@@ -90,7 +50,7 @@ let connect = function (config) {
       } else {
         for (let i = 0; i < dbs.databases.length; i++) {
           let dbName = dbs.databases[i].name;
-          if(dbName) {
+          if (dbName) {
             if (config.mongodb.whitelist.length !== 0) {
               if (!_.includes(config.mongodb.whitelist, dbName)) {
                 continue;
@@ -119,6 +79,66 @@ let connect = function (config) {
     });
   };
 
+  function setupAdminModeDatabases(db) {
+    let adminDb = db.admin();
+    connectionData.adminDb = adminDb;
+
+    if (!config.mongodb.adminUsername || config.mongodb.adminUsername.length === 0) {
+      if (config.options.console) console.log('Admin Database connected');
+      connectionData.updateDatabases(adminDb);
+    } else {
+      //auth details were supplied, authenticate admin account with them
+      adminDb.authenticate(config.mongodb.adminUsername, config.mongodb.adminPassword, function (err) {
+        if (err) {
+          //TODO: handle error
+          console.error(err);
+        }
+
+        if (config.options.console) console.log('Admin Database connected');
+        connectionData.updateDatabases(adminDb);
+      });
+    }
+  }
+
+  function setupDefualtDatabasae(db) {
+    var currentDbName = db.databaseName;
+    if (config.options.console) console.log('Connected to ' + currentDbName + '...');
+    connectionData.connections[currentDbName] = db;
+    connectionData.databases.push(currentDbName);
+    connectionData.updateCollections(db, currentDbName);
+  }
+
+  function setupAuthDatabases(db) {
+    async.forEachSeries(config.mongodb.auth, function (auth, callback) {
+      if (auth.database) {
+        if (config.options.console) console.log('Connecting to ' + auth.database + '...');
+        connectionData.connections[auth.database] = db(auth.database);
+        connectionData.databases.push(auth.database);
+
+        if (typeof auth.username !== 'undefined' && auth.username.length !== 0) {
+          connectionData.connections[auth.database].authenticate(auth.username, auth.password, function (err, success) {
+            if (err) {
+              //TODO: handle error
+              console.error(err);
+            }
+
+            if (!success) {
+              console.error('Could not authenticate to database "' + auth.database + '"');
+            }
+
+            connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
+            if (config.options.console) console.log('Database ' + auth.database + ' connected');
+            callback();
+          });
+        } else {
+          connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
+          if (config.options.console) console.log('Database ' + auth.database + ' connected');
+          callback();
+        }
+      }
+    });
+  }
+
   // connect to mongodb database
   function processOpenDatabase(err, db) {
     if (err) {
@@ -126,69 +146,60 @@ let connect = function (config) {
     }
 
     if (config.options.console) console.log('Database connected');
-	
-	  connectionData.mainConn = db;
+
+    connectionData.mainConn = db;
 
     //Check if admin features are on
     if (config.mongodb.admin === true) {
-	    let adminDb = db.admin();
-      connectionData.adminDb = adminDb;
-
-      if (!config.mongodb.adminUsername || config.mongodb.adminUsername.length === 0) {
-        if (config.options.console) console.log('Admin Database connected');
-        connectionData.updateDatabases(adminDb);
-      } else {
-        //auth details were supplied, authenticate admin account with them
-        adminDb.authenticate(config.mongodb.adminUsername, config.mongodb.adminPassword, function (err) {
-          if (err) {
-            //TODO: handle error
-            console.error(err);
-          }
-
-          if (config.options.console) console.log('Admin Database connected');
-          connectionData.updateDatabases(adminDb);
-        });
-      }
+      setupAdminModeDatabases(db);
     } else {
       //Regular user authentication
       if (typeof config.mongodb.auth === 'undefined' || config.mongodb.auth.length === 0 || !config.mongodb.auth[0].database) {
         // no auth list specified so use the database from the connection string
-        var currentDbName = db.databaseName;
-        if (config.options.console) console.log('Connected to ' + currentDbName + '...');
-        connectionData.connections[currentDbName] = db;
-        connectionData.databases.push(currentDbName);
-        connectionData.updateCollections(db, currentDbName);
+        setupDefualtDatabasae(db);
       }
       else {
-        async.forEachSeries(config.mongodb.auth, function (auth, callback) {
-          if(auth.database) {
-            if (config.options.console) console.log('Connecting to ' + auth.database + '...');
-            connectionData.connections[auth.database] = connectionData.mainConn.db(auth.database);
-            connectionData.databases.push(auth.database);
-
-            if (typeof auth.username !== 'undefined' && auth.username.length !== 0) {
-              connectionData.connections[auth.database].authenticate(auth.username, auth.password, function (err, success) {
-                if (err) {
-                  //TODO: handle error
-                  console.error(err);
-                }
-
-                if (!success) {
-                  console.error('Could not authenticate to database "' + auth.database + '"');
-                }
-
-                connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
-                if (config.options.console) console.log('Database ' + auth.database + ' connected');
-                callback();
-              });
-            } else {
-              connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
-              if (config.options.console) console.log('Database ' + auth.database + ' connected');
-              callback();
-            }
-          }
-        });
+        setupAuthDatabases(db);
       }
+    }
+  }
+
+  // connection options
+  let dbOptions = {
+    auto_reconnect: config.mongodb.autoReconnect,
+    poolSize:       config.mongodb.poolSize,
+    ssl:            config.mongodb.ssl,
+    sslValidate:    config.mongodb.sslValidate,
+    sslCA:          config.mongodb.sslCA,
+  };
+
+  // database connection
+  if (config.mongodb.connectionString) {
+    mongodb.MongoClient.connect(config.mongodb.connectionString, dbOptions, processOpenDatabase);
+  }
+  else {
+    // set up database using legacy configuration
+    let host = config.mongodb.server  || 'localhost';
+    let port = config.mongodb.port    || mongodb.Connection.DEFAULT_PORT;
+
+    if (config.mongodb.useSSL) {
+      console.error('Please update config file to use mongodb.ssl instead of mongodb.useSSL. Copying value for now.');
+      config.mongodb.ssl = config.mongodb.useSSL;
+    }
+
+    let db;
+
+    if (Array.isArray(host)) {
+      host = host.map(function (host) {
+        return new mongodb.Server(host, port, dbOptions);
+      });
+
+      db = new mongodb.Db('local', new mongodb.ReplSet(host), { safe: true, w: 0 });
+      db.open(processOpenDatabase);
+    }
+    else  {
+      db = new mongodb.Db('local', new mongodb.Server(host, port, dbOptions), { safe: true });
+      db.open(processOpenDatabase);
     }
   }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const async = require('async');
 const mongodb = require('mongodb');
 
 let connect = function (config) {
@@ -109,7 +108,7 @@ let connect = function (config) {
   }
 
   function setupAuthDatabases(db) {
-    async.forEachSeries(config.mongodb.auth, function (auth, callback) {
+    config.mongodb.auth.forEach(function (auth) {
       if (auth.database) {
         if (config.options.console) console.log('Connecting to ' + auth.database + '...');
         connectionData.connections[auth.database] = db(auth.database);
@@ -128,12 +127,10 @@ let connect = function (config) {
 
             connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
             if (config.options.console) console.log('Database ' + auth.database + ' connected');
-            callback();
           });
         } else {
           connectionData.updateCollections(connectionData.connections[auth.database], auth.database);
           if (config.options.console) console.log('Database ' + auth.database + ' connected');
-          callback();
         }
       }
     });
@@ -164,20 +161,21 @@ let connect = function (config) {
     }
   }
 
-  // connection options
-  let dbOptions = {
-    auto_reconnect: config.mongodb.autoReconnect,
-    poolSize:       config.mongodb.poolSize,
-    ssl:            config.mongodb.ssl,
-    sslValidate:    config.mongodb.sslValidate,
-    sslCA:          config.mongodb.sslCA,
-  };
-
   // database connection
   if (config.mongodb.connectionString) {
-    mongodb.MongoClient.connect(config.mongodb.connectionString, dbOptions, processOpenDatabase);
+    mongodb.MongoClient.connect(config.mongodb.connectionString, processOpenDatabase);
   }
   else {
+
+    // connection options
+    let dbOptions = {
+      auto_reconnect: config.mongodb.autoReconnect,
+      poolSize:       config.mongodb.poolSize,
+      ssl:            config.mongodb.ssl,
+      sslValidate:    config.mongodb.sslValidate,
+      sslCA:          config.mongodb.sslCA,
+    };
+
     // set up database using legacy configuration
     let host = config.mongodb.server  || 'localhost';
     let port = config.mongodb.port    || mongodb.Connection.DEFAULT_PORT;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "url": "git://github.com/mongo-express/mongo-express.git"
   },
   "dependencies": {
-    "async": "2.0.1",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "1.15.2",
     "busboy": "^0.2.13",


### PR DESCRIPTION
For  #272 

Added environment variable ME_CONFIG_MONGODB_URL, also --url command line parameter and connectionString option to the configuration object.

When connection string is specified other connection options (like ssl, etc) are ignored. In theory these could still be used but when I was doing this I still got errors from atlas about the replica set.

Since you can specify a database in the connection string. I connect to this database if the configuration does not specify a limited set of databases.