### PR TITLE
Handle Binary data in primary key

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -143,8 +143,13 @@ exports.to_display = function (input) {
 exports.stringDocIDs = function (input) {
 
   // Turns {_bsontype: ' ObjectID', id:12345... } into a plain string
-  if (input && typeof input === 'object' && input._bsontype === 'ObjectID') {
-    return input.toString();
+  if (input && typeof input === 'object') {
+    switch (input._bsontype) {
+      case 'ObjectID':
+        return input.toString();
+      case 'Binary':
+        return input.toJSON();
+    }
   }
 
   return input;

--- a/lib/router.js
+++ b/lib/router.js
@@ -159,6 +159,12 @@ const router = function (config) {
     try {
       obj_id = new mongodb.ObjectID.createFromHexString(id);
     } catch (err) {
+      try {
+        // Is it a GUID?
+        obj_id = new mongodb.Binary(new Buffer(id, 'base64'), 3);
+      } catch (err) {
+        // Silence GUID error as well
+      }
       // Silence the error
     }
 

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block title %}{{ document._id|to_string }}{% endblock %}
+{% block title %}{{ document._id|stringDocIDs|to_string }}{% endblock %}
 
 
 {% block styles %}


### PR DESCRIPTION
As discussed in issue #367 this PR addresses the issue that documents with a Binary as primary key (as opposed to ObjectID) are not accessible with mongo-express. Please note that there is certainly room for improvement here. But it works on my machine. :see_no_evil: