### PR TITLE
Prevent uncaught error if collection has been deleted.

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -154,6 +154,10 @@ var routes = function (config) {
 
     req.collection.find(query, projection, query_options).toArray(function (err, items) {
       req.collection.stats(function (err, stats) {
+        if (stats === undefined) {
+          req.session.error = 'Collection not found!';
+          return res.redirect('back');
+        }
         req.collection.indexes(function (err, indexes) {
           req.collection.count(query, null, function (err, count) {
             //Pagination


### PR DESCRIPTION
If one is at the 'Viewing Database' screen for a database with collections where collections are displayed.  If those collections are dropped (using the CLI), then one attempts to click on a collection (without first doing a refresh), the node process fails due to an uncaught error at: https://github.com/mongo-express/mongo-express/blob/master/lib/routes/collection.js#L231

`TypeError: Cannot read property 'indexSizes' of undefined`


