### PR TITLE
Typo on plural of index

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -196,7 +196,7 @@
 
       <div class="modal-header">
         <button class="close" data-dismiss="modal">×</button>
-        <h2>Add Indexs</h2>
+        <h2>Add Indexes</h2>
         <span>
           A document that contains the field and value pairs where the field
           is the index key. 1 for an ascending and -1 for a descending index.


### PR DESCRIPTION
It seems we've been using indexes, so I went with that. I prefer that because it seems easier for ESL speakers. That said, indices seems to be slightly more common.

https://books.google.com/ngrams/graph?content=indexes%2Cindices&year_start=1800&year_end=2010&corpus=15&smoothing=3&share=&direct_url=t1%3B%2Cindexes%3B%2Cc0%3B.t1%3B%2Cindices%3B%2Cc0