### PR TITLE
Fix bug in filters that mistakenly converts non-Binary and non-Object…

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -148,8 +148,9 @@ exports.stringDocIDs = function (input) {
       case 'Binary':
         return input.toJSON();
       case 'ObjectID':
-      default:
         return input.toString();
+      default:
+        return input;
     }
   }
 


### PR DESCRIPTION
…ID objects into the string '[object Object]'.


The current filters.js is converting all nested objects into the string "[object Object]" in the collection view. This change to the filters.js makes it so any objects that are not Binary nor ObjectID will be returned untouched.