### PR TITLE
Ensure mongo is never left uninitialised

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var mongo;
+var mongo = {
+  // setting the connection string will only give access to that database
+  // to see more databases you need to set mongodb.admin to true or add databases to the mongodb.auth list
+  connectionString: process.env.ME_CONFIG_MONGODB_SERVER ? '' : process.env.ME_CONFIG_MONGODB_URL,
+};
 
 // Accesing Bluemix variable to get MongoDB info
 if (process.env.VCAP_SERVICES) {
@@ -9,12 +13,6 @@ if (process.env.VCAP_SERVICES) {
   if (env[dbLabel]) {
     mongo = env[dbLabel][0].credentials;
   }
-} else {
-  mongo = {
-    // setting the connection string will only give access to that database
-    // to see more databases you need to set mongodb.admin to true or add databases to the mongodb.auth list
-    connectionString: process.env.ME_CONFIG_MONGODB_SERVER ? '' : process.env.ME_CONFIG_MONGODB_URL,
-  };
 }
 
 var meConfigMongodbServer = process.env.ME_CONFIG_MONGODB_SERVER ? process.env.ME_CONFIG_MONGODB_SERVER.split(',') : false;


### PR DESCRIPTION
Previously if there *was* an environment variable named `VCAP_SERVICES` but it *didn't* contain the key `'mongodb-2.4'`, startup would fail with `TypeError: Cannot read property 'connectionString' of undefined` on line 25.