### PR TITLE
[Fixes #405] Exports respect sort order; Exports export all items

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -101,14 +101,20 @@ var routes = function (config) {
     return result;
   };
 
-  exp._getQueryOptions = function (req) {
-    var limit = config.options.documentsPerPage;
-    var skip = parseInt(req.query.skip, 10) || 0;
+  exp._getSort = function (req) {
     var sort = req.query.sort || {};
 
     for (var i in sort) {
       sort[i] = parseInt(sort[i], 10);
     }
+
+    return sort;
+  };
+
+  exp._getQueryOptions = function (req) {
+    var limit = config.options.documentsPerPage;
+    var skip = parseInt(req.query.skip, 10) || 0;
+    var sort = exp._getSort(req);
 
     var query_options = {
       sort:   sort,
@@ -316,7 +322,9 @@ var routes = function (config) {
     var projection;
 
     try {
-      query_options = exp._getQueryOptions(req, res);
+      query_options = {
+        sort: exp._getSort(req),
+      };
       query = exp._getQuery(req, res);
       projection = exp._getProjection(req, res);
     } catch (err) {
@@ -337,7 +345,9 @@ var routes = function (config) {
     var projection;
 
     try {
-      query_options = exp._getQueryOptions(req, res);
+      query_options = {
+        sort: exp._getSort(req),
+      };
       query = exp._getQuery(req, res);
       projection = exp._getProjection(req, res);
     } catch (err) {
@@ -359,7 +369,9 @@ var routes = function (config) {
     var projection;
 
     try {
-      query_options = exp._getQueryOptions(req, res);
+      query_options = {
+        sort: exp._getSort(req),
+      };
       query = exp._getQuery(req, res);
       projection = exp._getProjection(req, res);
     } catch (err) {

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -342,7 +342,7 @@
   <div class="row">
     <div class="col-sm-6 {% if !settings.read_only %}col-lg-3{% endif %}">
       <div class="well">
-      <a href="{{ baseHref }}db/{{ dbName }}/export/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}" class="btn btn-warning btn-block">
+      <a href="{{ baseHref }}db/{{ dbName }}/export/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}" class="btn btn-warning btn-block">
         <span class="glyphicon glyphicon-floppy-save"></span><br>Export Standard
       </a>
       </div>
@@ -350,7 +350,7 @@
 
     <div class="col-sm-6 {% if !settings.read_only %}col-lg-3{% endif %}">
       <div class="well">
-      <a href="{{ baseHref }}db/{{ dbName }}/expArr/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}" class="btn btn-warning btn-block">
+      <a href="{{ baseHref }}db/{{ dbName }}/expArr/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}" class="btn btn-warning btn-block">
         <span class="glyphicon glyphicon-floppy-save"></span><br>Export --jsonArray
       </a>
       </div>
@@ -358,7 +358,7 @@
 
     <div class="col-sm-6 {% if !settings.read_only %}col-lg-3{% endif %}">
       <div class="well">
-      <a href="{{ baseHref }}db/{{ dbName }}/expCsv/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}" class="btn btn-warning btn-block">
+      <a href="{{ baseHref }}db/{{ dbName }}/expCsv/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}" class="btn btn-warning btn-block">
         <span class="glyphicon glyphicon-floppy-save"></span><br>Export --csv
       </a>
       </div>


### PR DESCRIPTION
Fixes https://github.com/mongo-express/mongo-express/issues/405

1. I realized that the export URLs didn't have any sort info, so I added that. (Yay copy and paste...)
2. When exporting, we no longer include `limit` or `skip`, so everything that `collection.find()` returns is exported.