### PR TITLE
Allow readonly config by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_BASICAUTH_PASSWORD`    | `pass`          | mongo-express web login password.
     `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
     `ME_CONFIG_OPTIONS_EDITORTHEME`   | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
+    `ME_CONFIG_OPTIONS_READONLY`      | `false`         | if readOnly is true, components of writing are not visible.
     `ME_CONFIG_SITE_SSL_ENABLED`      | `false`         | Enable SSL.
     `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
     `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.

--- a/config.default.js
+++ b/config.default.js
@@ -127,7 +127,7 @@ module.exports = {
     subprocessTimeout: 300,
 
     //readOnly: if readOnly is true, components of writing are not visible.
-    readOnly: false,
+    readOnly: process.env.ME_CONFIG_OPTIONS_READONLY || false,
 
     //collapsibleJSON: if set to true, jsons will be displayed collapsible
     collapsibleJSON: true,


### PR DESCRIPTION
I used mongo-express as a docker container.
I need to set readOnly config to true, but I needed create a volume to change this config on my host.

With this change, I'll pass environment variable to set readOnly, without the need to create a volume to config.js file.

Thanks