### PR TITLE
Don't enter in edit mode with selection

### DIFF
--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -103,7 +103,9 @@ function makeCollectionUrl() {
 }
 
 window.loadDocument = function (url) {
-  location.href = url;
+  if( window.getSelection() == "" ) {
+    location.href = url;
+  }
 };
 
 $document.ready(function () {

--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -103,7 +103,7 @@ function makeCollectionUrl() {
 }
 
 window.loadDocument = function (url) {
-  if( window.getSelection() == "" ) {
+  if (window.getSelection() === '') {
     location.href = url;
   }
 };


### PR DESCRIPTION
Into Collection page are listed all documents, if there is a mouse selection (for copy-paste a string) then mongo-express don't enter in Edit Mode for Document.