### PR TITLE
Configurable full width layout using container-fluid vs container #457

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
     `ME_CONFIG_OPTIONS_EDITORTHEME`   | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
     `ME_CONFIG_OPTIONS_READONLY`      | `false`         | if readOnly is true, components of writing are not visible.
+    `ME_CONFIG_OPTIONS_FULLWIDTHLAYOUT`| `false`         | When set to true an alternative page layout is used utilizing full window width.
     `ME_CONFIG_SITE_SSL_ENABLED`      | `false`         | Enable SSL.
     `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
     `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.

--- a/config.default.js
+++ b/config.default.js
@@ -199,6 +199,9 @@ module.exports = {
 
     // noExport: if noExport is set to true, we won't show export buttons
     noExport: false,
+
+    // fullWidthLayout: When set to true an alternative page layout is used utilizing full window width
+    fullWidthLayout: process.env.ME_CONFIG_OPTIONS_FULLWIDTHLAYOUT || false,
   },
 
   // Specify the default keyname that should be picked from a document to display in collections list.

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -162,3 +162,8 @@ exports.stringDocIDs = function (input) {
 exports.is_embeddedDocumentNotation = function (input) {
   return /^(?:[a-zA-Z0-9_]+\.)+[a-zA-Z0-9_]+/.test(input);
 };
+
+
+exports.ternary = function (input, trueVal, falseVal) {
+  return input ? trueVal : falseVal;
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -40,6 +40,7 @@ const middleware = function (config) {
   app.set('me_collapsible_json', config.options.collapsibleJSON || false);
   app.set('me_collapsible_json_default_unfold', config.options.collapsibleJSONDefaultUnfold || false);
   app.set('me_no_export', config.options.noExport || false);
+  app.set('full_width_layout', config.options.fullWidthLayout || false);
   app.set('gridFSEnabled', config.options.gridFSEnabled || false);
 
   return app;

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -62,7 +62,7 @@
 </nav>
 
 
-<div class="container">
+<div class="{{ settings.full_width_layout | ternary('container-fluid', 'container') }}">
   <div class="row">
     <div class="col-md-12">
       <div class="page-header main-title">


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/495)
---
<!-- Reviewable:end -->
Although some buttons look odd when they are too wide. Especially if the browser window width is very large like spread across two monitors. Perhaps this could be improved further by adding some `maxWidth` or/and `flex-grow` etc. 
![FullWidth](https://user-images.githubusercontent.com/842962/63260528-791ca180-c281-11e9-8247-14a81fa36757.png)