### PR TITLE
Add support for client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,33 +123,38 @@ $ docker run -it --rm -p 8081:8081 --link YOUR_MONGODB_CONTAINER:mongo mongo-exp
 
 You can use the following [environment variables](https://docs.docker.com/reference/run/#env-environment-variables) to modify the container's configuration:
 
-    Name                              | Default         | Description
-    ----------------------------------|-----------------|------------
-    `ME_CONFIG_MONGODB_SERVER`        |`mongo` or `localhost`| MongoDB host name or IP address. The default is `localhost` in the config file and `mongo` in the docker image. If it is a replica set, use a comma delimited list of the host names.
-    `ME_CONFIG_MONGODB_PORT`          | `27017`         | MongoDB port.
-    `ME_CONFIG_MONGODB_URL`           | `mongodb://admin:pass@localhost:27017/db?ssl=false`
-    `ME_CONFIG_MONGODB_ENABLE_ADMIN`  | `false`         | Enable administrator access. Send strings: `"true"` or `"false"`.
-    `ME_CONFIG_MONGODB_ADMINUSERNAME` | ` `             | Administrator username.
-    `ME_CONFIG_MONGODB_ADMINPASSWORD` | ` `             | Administrator password.
-    `ME_CONFIG_MONGODB_AUTH_DATABASE` | `db`            | Database name (only needed if `ENABLE_ADMIN` is `"false"`).
-    `ME_CONFIG_MONGODB_AUTH_USERNAME` | `admin`         | Database username (only needed if `ENABLE_ADMIN` is `"false"`).
-    `ME_CONFIG_MONGODB_AUTH_PASSWORD` | `pass`          | Database password (only needed if `ENABLE_ADMIN` is `"false"`).
-    `ME_CONFIG_SITE_BASEURL`          | `/`             | Set the express baseUrl to ease mounting at a subdirectory. Remember to include a leading and trailing slash.
-    `ME_CONFIG_SITE_COOKIESECRET`     | `cookiesecret`  | String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.
-    `ME_CONFIG_SITE_SESSIONSECRET`    | `sessionsecret` | String used to sign the session ID cookie by [express-session middleware](https://www.npmjs.com/package/express-session).
-    `ME_CONFIG_BASICAUTH_USERNAME`    | ``              | mongo-express web login name. Sending an empty string will disable basic authentication.
-    `ME_CONFIG_BASICAUTH_PASSWORD`    | ``              | mongo-express web login password.
-    `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
-    `ME_CONFIG_OPTIONS_EDITORTHEME`   | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
-    `ME_CONFIG_OPTIONS_READONLY`      | `false`         | if readOnly is true, components of writing are not visible.
-    `ME_CONFIG_SITE_SSL_ENABLED`      | `false`         | Enable SSL.
-    `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
-    `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.
-    `ME_CONFIG_SITE_SSL_KEY_PATH`     | ` `             | SSL key file.
-    `ME_CONFIG_SITE_GRIDFS_ENABLED`   | `false`         | Enable gridFS to manage uploaded files.
-    `VCAP_APP_HOST`                   | `localhost`     | address that mongo-express will listen on for incoming connections.
-    `VCAP_APP_PORT`                   | `8081`          | port that mongo-express will run on.
-    `ME_CONFIG_MONGODB_CA_FILE`       | ``              | CA certificate File
+    Name                               | Default         | Description
+    -----------------------------------|-----------------|------------
+    `ME_CONFIG_MONGODB_SERVER`         |`mongo` or `localhost`| MongoDB host name or IP address. The default is `localhost` in the config file and `mongo` in the docker image. If it is a replica set, use a comma delimited list of the host names.
+    `ME_CONFIG_MONGODB_PORT`           | `27017`         | MongoDB port.
+    `ME_CONFIG_MONGODB_URL`            | `mongodb://admin:pass@localhost:27017/db?ssl=false`
+    `ME_CONFIG_MONGODB_ENABLE_ADMIN`   | `false`         | Enable administrator access. Send strings: `"true"` or `"false"`.
+    `ME_CONFIG_MONGODB_ADMINUSERNAME`  | ` `             | Administrator username.
+    `ME_CONFIG_MONGODB_ADMINPASSWORD`  | ` `             | Administrator password.
+    `ME_CONFIG_MONGODB_AUTH_DATABASE`  | `db`            | Database name (only needed if `ENABLE_ADMIN` is `"false"`).
+    `ME_CONFIG_MONGODB_AUTH_USERNAME`  | `admin`         | Database username (only needed if `ENABLE_ADMIN` is `"false"`).
+    `ME_CONFIG_MONGODB_AUTH_PASSWORD`  | `pass`          | Database password (only needed if `ENABLE_ADMIN` is `"false"`).
+    `ME_CONFIG_SITE_BASEURL`           | `/`             | Set the express baseUrl to ease mounting at a subdirectory. Remember to include a leading and trailing slash.
+    `ME_CONFIG_SITE_COOKIESECRET`      | `cookiesecret`  | String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.
+    `ME_CONFIG_SITE_SESSIONSECRET`     | `sessionsecret` | String used to sign the session ID cookie by [express-session middleware](https://www.npmjs.com/package/express-session).
+    `ME_CONFIG_BASICAUTH_USERNAME`     | ``              | mongo-express web login name. Sending an empty string will disable basic authentication.
+    `ME_CONFIG_BASICAUTH_PASSWORD`     | ``              | mongo-express web login password.
+    `ME_CONFIG_REQUEST_SIZE`           | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
+    `ME_CONFIG_OPTIONS_EDITORTHEME`    | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
+    `ME_CONFIG_OPTIONS_READONLY`       | `false`         | if readOnly is true, components of writing are not visible.
+    `ME_CONFIG_MONGODB_SSL`            | ``              | Connect to the mongod server using TLS.
+    `ME_CONFIG_MONGODB_SSLVALIDATE`    | `true`          | Validate mongod server certificate against CA.
+    `ME_CONFIG_MONGODB_CA_FILE`        | ``              | CA file for server certificate verification.
+    `ME_CONFIG_MONGODB_SSL_CRT_FILE`   | ``              | Certificate to use for client authentication.
+    `ME_CONFIG_MONGODB_SSL_KEY_FILE`   | ``              | Private key to use for client authentication.
+    `ME_CONFIG_MONGODB_SSL_CHECK_HOST` | `true`          | Verify that the mongod server certificate is issued to the server's hostname.
+    `ME_CONFIG_SITE_SSL_ENABLED`       | `false`         | Enable SSL for the site.
+    `ME_CONFIG_SITE_SSL_CRT_PATH`      | ` `             | SSL certificate file for the site.
+    `ME_CONFIG_SITE_SSL_KEY_PATH`      | ` `             | SSL key file for the site.
+    `ME_CONFIG_SITE_GRIDFS_ENABLED`    | `false`         | Enable gridFS to manage uploaded files.
+    `VCAP_APP_HOST`                    | `localhost`     | address that mongo-express will listen on for incoming connections.
+    `VCAP_APP_PORT`                    | `8081`          | port that mongo-express will run on.
+    `ME_CONFIG_MONGODB_CA_FILE`        | ``              | CA certificate File
     `ME_CONFIG_BASICAUTH_USERNAME_FILE`     | ``        | File version of ME_CONFIG_BASICAUTH_USERNAME
     `ME_CONFIG_BASICAUTH_PASSWORD_FILE`     | ``        | File version of ME_CONFIG_BASICAUTH_PASSWORD
     `ME_CONFIG_MONGODB_ADMINUSERNAME_FILE`  | ``        | File version of ME_CONFIG_MONGODB_ADMINUSERNAME

--- a/app.js
+++ b/app.js
@@ -88,6 +88,11 @@ if (commander.url) {
   }
 }
 
+if ((config.mongodb.sslCert && !config.mongodb.sslKey) || (!config.mongodb.sslCert && config.mongodb.sslKey)) {
+  console.error(clc.red('Both sslCert and sslKey must be provided to enable client verification.'));
+  process.exit(1);
+}
+
 config.mongodb.server = commander.host || config.mongodb.server;
 config.mongodb.port = commander.dbport || config.mongodb.port;
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -160,20 +160,29 @@ let connect = function (config) {
     }
   }
 
+  // connection options
+  const dbOptions = {
+    auto_reconnect: config.mongodb.autoReconnect,
+    poolSize:       config.mongodb.poolSize,
+    sslValidate:    config.mongodb.sslValidate,
+    sslCA:          config.mongodb.sslCA,
+    sslKey:         config.mongodb.sslKey,
+    sslCert:        config.mongodb.sslCert,
+  };
+
+  // Let the driver autodetect ssl if the option is unspecified since the parameter can be set in the connection string
+  if ('ssl' in config.mongodb) {
+    dbOptions.ssl = config.mongodb.ssl;
+  }
+
+  if ('checkServerIdentity' in config.mongodb) {
+    dbOptions.checkServerIdentity = config.mongodb.checkServerIdentity;
+  }
+
   // database connection
   if (config.mongodb.connectionString) {
-    mongodb.MongoClient.connect(config.mongodb.connectionString, processOpenDatabase);
+    mongodb.MongoClient.connect(config.mongodb.connectionString, dbOptions, processOpenDatabase);
   } else {
-
-    // connection options
-    let dbOptions = {
-      auto_reconnect: config.mongodb.autoReconnect,
-      poolSize:       config.mongodb.poolSize,
-      ssl:            config.mongodb.ssl,
-      sslValidate:    config.mongodb.sslValidate,
-      sslCA:          config.mongodb.sslCA,
-    };
-
     // set up database using legacy configuration
     let host = config.mongodb.server  || 'localhost';
     let port = config.mongodb.port || 27017;


### PR DESCRIPTION
Some MongoDB servers use client certificate validation, which requires clients to provide a key/cert pair. This commit lets mongo-express connect to such servers, and allows it to authenticate using x509 if the MONGODB-X509 mechanism is selected in the connection string.

It also fixes the MongoDB Atlas problem mentioned in commit cc38426 by only setting the SSL connection option if it's defined in the config file or an environment variable.