### PR TITLE
Fixed the "event-stream" package @ 3.x 404-ing due to a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "supertest": "^3.0.0",
     "webpack": "^2.4.1"
   },
+  "resolutions": {
+    "**/event-stream": "^4.0.1"
+  },
   "engines": {
     "node": ">=6.0.0",
     "npm": ">=3.0.0"


### PR DESCRIPTION
See https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident