### PR TITLE
Fix broken save document for UUID (BinData 3 & 4) since #473

### DIFF
--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -59,10 +59,18 @@
 
 {% block content %}
 
+{% if document._id._bsontype == 'Binary' %}
+<form method="POST"
+  id="documentEditForm"
+  action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}"
+>
+{% else %}
 <form method="POST"
   id="documentEditForm"
   action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}"
 >
+{% endif %}
+
   {% if docLength > 10 %}
     <div>
       {% if !settings.read_only %}


### PR DESCRIPTION
Since #473 documents can be open for UUID 3 & 4 but the save button does not work.

This simple PR is fixing this issue