### PR TITLE
Support for collection view showing UUIDs and searches allowing UUIDs (BinData type 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,20 @@ Creates a new ISODate object with current time.
 
 Uses ISODate object with the given timestamp.
 
+**UUID**
+
+    UUID()
+
+Creates a new UUID v4.
+
+Can also be used `new UUID()` (note the `new` keyword there).
+
+    UUID(uuid)
+
+Uses UUID v4 with the given 24-digit hexadecimal string.
+
+Example: `UUID("dee11d4e-63c6-4d90-983c-5c9f1e79e96c")` or `UUID("dee11d4e63c64d90983c5c9f1e79e96c")`
+
 **DBRef/Dbref**
 
     DBRef(collection, objectID)

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -149,12 +149,24 @@ export const to_display = function (input) {
 };
 
 function uuid4ToString(input) {
-  const hex = input.toString('hex');
+  const hex = input.toString('hex'); // same of input.buffer.toString('hex')
   return `UUID("${addHyphensToUUID(hex)}")`;
 }
 
+/**
+ * @typedef {import('bson').Binary} Binary
+ * @typedef {import('bson').ObjectId} ObjectId
+ */
+
+/**
+ * Convert BSON into a plain string:
+ * - { _bsontype: 'ObjectID', id: <Buffer> } => <ObjectId>
+ * - { _bsontype: 'Binary', __id: undefined, sub_type: 4, position: 16, buffer: <Buffer> } => <UUID>
+ * - { _bsontype: 'Binary', __id: undefined, sub_type: <number_not_4>, position: 16, buffer: <Buffer> } => <Binary>
+ * @param {ObjectId|Binary|*} input
+ * @returns {string}
+ */
 export const stringDocIDs = function (input) {
-  // Turns {_bsontype: ' ObjectID', id:12345... } into a plain string
   if (input && typeof input === 'object') {
     switch (input._bsontype) {
       case 'Binary':

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -147,35 +147,9 @@ export const to_display = function (input) {
 };
 
 function uuid4ToString(input) {
-  var hex = Base64ToHex(input.buffer.toString('base64')); // don't use BinData's hex function because it has bugs
+  var hex = input.toString('hex');
   var uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
   return 'UUID("' + uuid + '")';
-}
-
-function Base64ToHex(base64) {
-  var base64Digits = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-  var hexDigits = '0123456789abcdef';
-  var hex = '';
-  for (var i = 0; i < 24;) {
-    var e1 = base64Digits.indexOf(base64[i++]);
-    var e2 = base64Digits.indexOf(base64[i++]);
-    var e3 = base64Digits.indexOf(base64[i++]);
-    var e4 = base64Digits.indexOf(base64[i++]);
-    var c1 = (e1 << 2) | (e2 >> 4);
-    var c2 = ((e2 & 15) << 4) | (e3 >> 2);
-    var c3 = ((e3 & 3) << 6) | e4;
-    hex += hexDigits[c1 >> 4];
-    hex += hexDigits[c1 & 15];
-    if (e3 !== 64) {
-      hex += hexDigits[c2 >> 4];
-      hex += hexDigits[c2 & 15];
-    }
-    if (e4 !== 64) {
-      hex += hexDigits[c3 >> 4];
-      hex += hexDigits[c3 & 15];
-    }
-  }
-  return hex;
 }
 
 export const stringDocIDs = function (input) {

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,3 +1,5 @@
+import { addHyphensToUUID } from './utils.js';
+
 export const json = function (input) {
   return JSON.stringify(input, null, '    ');
 };
@@ -148,8 +150,7 @@ export const to_display = function (input) {
 
 function uuid4ToString(input) {
   const hex = input.toString('hex');
-  const uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
-  return 'UUID("' + uuid + '")';
+  return `UUID("${addHyphensToUUID(hex)}")`;
 }
 
 export const stringDocIDs = function (input) {

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -150,7 +150,7 @@ export const to_display = function (input) {
 
 function uuid4ToString(input) {
   const hex = input.toString('hex'); // same of input.buffer.toString('hex')
-  return `UUID("${addHyphensToUUID(hex)}")`;
+  return addHyphensToUUID(hex);
 }
 
 /**

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -157,7 +157,7 @@ export const stringDocIDs = function (input) {
   if (input && typeof input === 'object') {
     switch (input._bsontype) {
       case 'Binary':
-        if (input.sub_type === 4){
+        if (input.sub_type === 4) {
           return uuid4ToString(input);
         }
         return input.toJSON();

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -147,8 +147,8 @@ export const to_display = function (input) {
 };
 
 function uuid4ToString(input) {
-  var hex = input.toString('hex');
-  var uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
+  const hex = input.toString('hex');
+  const uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
   return 'UUID("' + uuid + '")';
 }
 

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -151,6 +151,9 @@ export const stringDocIDs = function (input) {
   if (input && typeof input === 'object') {
     switch (input._bsontype) {
       case 'Binary':
+        if (input.sub_type == 4){
+          return uuid4ToString(input);
+        }
         return input.toJSON();
       case 'ObjectID':
         return input.toString();
@@ -171,3 +174,35 @@ export const is_embeddedDocumentNotation = function (input) {
 export const is_URL = function (input) {
   return /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/.*)?$/.test(input);
 };
+
+function uuid4ToString(input) {
+    var hex = Base64ToHex(input.buffer.toString('base64')); // don't use BinData's hex function because it has bugs
+    var uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
+    return 'UUID("' + uuid + '")';
+}
+
+function Base64ToHex(base64) {
+    var base64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    var hexDigits = "0123456789abcdef";
+    var hex = "";
+    for (var i = 0; i < 24; ) {
+        var e1 = base64Digits.indexOf(base64[i++]);
+        var e2 = base64Digits.indexOf(base64[i++]);
+        var e3 = base64Digits.indexOf(base64[i++]);
+        var e4 = base64Digits.indexOf(base64[i++]);
+        var c1 = (e1 << 2) | (e2 >> 4);
+        var c2 = ((e2 & 15) << 4) | (e3 >> 2);
+        var c3 = ((e3 & 3) << 6) | e4;
+        hex += hexDigits[c1 >> 4];
+        hex += hexDigits[c1 & 15];
+        if (e3 != 64) {
+            hex += hexDigits[c2 >> 4];
+            hex += hexDigits[c2 & 15];
+        }
+        if (e4 != 64) {
+            hex += hexDigits[c3 >> 4];
+            hex += hexDigits[c3 & 15];
+        }
+    }
+    return hex;
+}

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -146,12 +146,44 @@ export const to_display = function (input) {
   return entifyGTLTAmp(input.toString());
 };
 
+function uuid4ToString(input) {
+  var hex = Base64ToHex(input.buffer.toString('base64')); // don't use BinData's hex function because it has bugs
+  var uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
+  return 'UUID("' + uuid + '")';
+}
+
+function Base64ToHex(base64) {
+  var base64Digits = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  var hexDigits = '0123456789abcdef';
+  var hex = '';
+  for (var i = 0; i < 24;) {
+    var e1 = base64Digits.indexOf(base64[i++]);
+    var e2 = base64Digits.indexOf(base64[i++]);
+    var e3 = base64Digits.indexOf(base64[i++]);
+    var e4 = base64Digits.indexOf(base64[i++]);
+    var c1 = (e1 << 2) | (e2 >> 4);
+    var c2 = ((e2 & 15) << 4) | (e3 >> 2);
+    var c3 = ((e3 & 3) << 6) | e4;
+    hex += hexDigits[c1 >> 4];
+    hex += hexDigits[c1 & 15];
+    if (e3 !== 64) {
+      hex += hexDigits[c2 >> 4];
+      hex += hexDigits[c2 & 15];
+    }
+    if (e4 !== 64) {
+      hex += hexDigits[c3 >> 4];
+      hex += hexDigits[c3 & 15];
+    }
+  }
+  return hex;
+}
+
 export const stringDocIDs = function (input) {
   // Turns {_bsontype: ' ObjectID', id:12345... } into a plain string
   if (input && typeof input === 'object') {
     switch (input._bsontype) {
       case 'Binary':
-        if (input.sub_type == 4){
+        if (input.sub_type === 4){
           return uuid4ToString(input);
         }
         return input.toJSON();
@@ -174,35 +206,3 @@ export const is_embeddedDocumentNotation = function (input) {
 export const is_URL = function (input) {
   return /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/.*)?$/.test(input);
 };
-
-function uuid4ToString(input) {
-    var hex = Base64ToHex(input.buffer.toString('base64')); // don't use BinData's hex function because it has bugs
-    var uuid = hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4) + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
-    return 'UUID("' + uuid + '")';
-}
-
-function Base64ToHex(base64) {
-    var base64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-    var hexDigits = "0123456789abcdef";
-    var hex = "";
-    for (var i = 0; i < 24; ) {
-        var e1 = base64Digits.indexOf(base64[i++]);
-        var e2 = base64Digits.indexOf(base64[i++]);
-        var e3 = base64Digits.indexOf(base64[i++]);
-        var e4 = base64Digits.indexOf(base64[i++]);
-        var c1 = (e1 << 2) | (e2 >> 4);
-        var c2 = ((e2 & 15) << 4) | (e3 >> 2);
-        var c3 = ((e3 & 3) << 6) | e4;
-        hex += hexDigits[c1 >> 4];
-        hex += hexDigits[c1 & 15];
-        if (e3 != 64) {
-            hex += hexDigits[c2 >> 4];
-            hex += hexDigits[c2 & 15];
-        }
-        if (e4 != 64) {
-            hex += hexDigits[c3 >> 4];
-            hex += hexDigits[c3 & 15];
-        }
-    }
-    return hex;
-}

--- a/lib/router.js
+++ b/lib/router.js
@@ -67,6 +67,7 @@ const router = async function (config) {
 
   appRouter.use('/public', express.static(fileURLToPath(new URL('../build', import.meta.url))));
 
+  appRouter.use(bodyParser.json());
   // Set request size limit
   appRouter.use(bodyParser.urlencoded({
     extended: true,

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -68,7 +68,7 @@ const routes = function (config) {
         R(value) {
           return new RegExp(value, 'i');
         },
-        U: function (value) {
+        U(value) {
           return new mongodb.Binary(Buffer.from(value.replace(/-/g, ''), 'hex'), 4);
         },
         // if type == S, no conversion done

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -1,6 +1,7 @@
 import os from 'node:os';
 import _ from 'lodash-es';
 import { EJSON } from 'bson';
+import mongodb from 'mongodb';
 import * as bson from '../bson.js';
 import * as utils from '../utils.js';
 import csv from '../csv.js';
@@ -66,6 +67,9 @@ const routes = function (config) {
         // If type == R, convert to RegExp
         R(value) {
           return new RegExp(value, 'i');
+        },
+        U: function (value) {
+          return new mongodb.Binary(Buffer.from(value.replace(/-/g,''), 'hex'), 4);
         },
         // if type == S, no conversion done
         S(value) {

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -69,7 +69,7 @@ const routes = function (config) {
           return new RegExp(value, 'i');
         },
         U: function (value) {
-          return new mongodb.Binary(Buffer.from(value.replace(/-/g,''), 'hex'), 4);
+          return new mongodb.Binary(Buffer.from(value.replace(/-/g, ''), 'hex'), 4);
         },
         // if type == S, no conversion done
         S(value) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -114,6 +114,10 @@ export const buildDocumentURL = function (base, dbName, collectionName, document
   return url;
 };
 
+export const addHyphensToUUID = function (hex) {
+  return `${hex.substring(0, 8)}-${hex.substr(8, 4)}-${hex.substr(12, 4)}-${hex.substr(16, 4)}-${hex.substr(20, 12)}`;
+};
+
 export const isValidDatabaseName = function (name) {
   if (!name || name.length > 63) {
     return false;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -115,7 +115,7 @@ export const buildDocumentURL = function (base, dbName, collectionName, document
 };
 
 export const addHyphensToUUID = function (hex) {
-  return `${hex.substring(0, 8)}-${hex.substr(8, 4)}-${hex.substr(12, 4)}-${hex.substr(16, 4)}-${hex.substr(20, 12)}`;
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 };
 
 export const isValidDatabaseName = function (name) {

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -102,6 +102,7 @@
             <option value="J" {% if type == 'J' %}selected {% endif %}>JSON, bool</option>
             <option value="N" {% if type == 'N' %}selected {% endif %}>Number</option>
             <option value="O" {% if type == 'O' %}selected {% endif %}>ObjectId</option>
+            <option value="U" {% if type == 'U' %}selected {% endif %}>UUID (type 4)</option>
           </select>
         </div>
         <div class="form-group col-sm-6 col-md-2">

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -102,7 +102,7 @@
             <option value="J" {% if type == 'J' %}selected {% endif %}>JSON, bool</option>
             <option value="N" {% if type == 'N' %}selected {% endif %}>Number</option>
             <option value="O" {% if type == 'O' %}selected {% endif %}>ObjectId</option>
-            <option value="U" {% if type == 'U' %}selected {% endif %}>UUID (type 4)</option>
+            <option value="U" {% if type == 'U' %}selected {% endif %}>UUID (v4)</option>
           </select>
         </div>
         <div class="form-group col-sm-6 col-md-2">

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "pre-commit": "1.2.2",
     "renderjson": "dozoisch/renderjson#cd0ef870c1298d53f09555da54e4bf57a0d21414",
     "supertest": "^6.2.4",
-    "uuid": "^9.0.0",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mongodb-query-parser": "^2.4.6",
     "morgan": "^1.10.0",
     "nyc": "^15.1.0",
+    "patch-package": "^6.4.7",
     "serve-favicon": "^2.5.0"
   },
   "devDependencies": {
@@ -95,6 +96,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "postinstall": "patch-package",
     "lint": "eslint .",
     "start": "cross-env NODE_ENV=production node app.js",
     "start-dev": "concurrently --kill-others \"nodemon app.js --watch lib\" \"npm run build-dev\"",

--- a/patches/ejson-shell-parser+1.1.3.patch
+++ b/patches/ejson-shell-parser+1.1.3.patch
@@ -1,0 +1,42 @@
+diff --git a/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.dev.js b/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.dev.js
+index dd902df..07db965 100644
+--- a/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.dev.js
++++ b/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.dev.js
+@@ -2,6 +2,7 @@
+ 
+ Object.defineProperty(exports, '__esModule', { value: true });
+ 
++var crypto = require('node:crypto');
+ var acorn = require('acorn');
+ var bson = require('bson');
+ 
+@@ -154,7 +155,7 @@ var SCOPE = {
+     return new bson__namespace.Binary(Buffer.from(d, 'base64'), t);
+   },
+   UUID: function UUID(u) {
+-    return new bson__namespace.Binary(Buffer.from(u.replace(/-/g, ''), 'hex'), 4);
++    return new bson__namespace.Binary(Buffer.from((u || crypto.randomUUID()).replace(/-/g, ''), 'hex'), 4);
+   },
+   Code: function Code(c, s) {
+     return new bson__namespace.Code(c, s);
+diff --git a/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.prod.js b/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.prod.js
+index dd902df..07db965 100644
+--- a/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.prod.js
++++ b/node_modules/ejson-shell-parser/dist/ejson-shell-parser.cjs.prod.js
+@@ -2,6 +2,7 @@
+ 
+ Object.defineProperty(exports, '__esModule', { value: true });
+ 
++var crypto = require('node:crypto');
+ var acorn = require('acorn');
+ var bson = require('bson');
+ 
+@@ -154,7 +155,7 @@ var SCOPE = {
+     return new bson__namespace.Binary(Buffer.from(d, 'base64'), t);
+   },
+   UUID: function UUID(u) {
+-    return new bson__namespace.Binary(Buffer.from(u.replace(/-/g, ''), 'hex'), 4);
++    return new bson__namespace.Binary(Buffer.from((u || crypto.randomUUID()).replace(/-/g, ''), 'hex'), 4);
+   },
+   Code: function Code(c, s) {
+     return new bson__namespace.Code(c, s);

--- a/patches/mongodb-query-parser+2.4.6.patch
+++ b/patches/mongodb-query-parser+2.4.6.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/mongodb-query-parser/lib/stringify.js b/node_modules/mongodb-query-parser/lib/stringify.js
+index 93904b0..fbdc7dc 100644
+--- a/node_modules/mongodb-query-parser/lib/stringify.js
++++ b/node_modules/mongodb-query-parser/lib/stringify.js
+@@ -49,7 +49,8 @@ const BSON_TO_JS_STRING = {
+   Binary: function(v) {
+     const subType = v.sub_type;
+     if (subType === 4) {
+-      return `UUID("${v.buffer.toString('hex')}")`;
++      const uuidHex = v.buffer.toString('hex')
++      return `UUID("${uuidHex.slice(0, 8)}-${uuidHex.slice(8, 12)}-${uuidHex.slice(12, 16)}-${uuidHex.slice(16, 20)}-${uuidHex.slice(20, 32)}")`;
+     }
+     return `BinData(${subType.toString(16)}, '${v.buffer.toString('base64')}')`;
+   },

--- a/test/lib/filtersSpec.js
+++ b/test/lib/filtersSpec.js
@@ -13,7 +13,7 @@ describe('filters', function () {
         const hex = UUID.split('-').join('');
         const buffer = new Buffer.from(hex, 'hex');
         const input = new Binary(buffer, Binary.SUBTYPE_UUID);
-        expect(stringDocIDs(input)).to.equal(`UUID("${UUID}")`);
+        expect(stringDocIDs(input)).to.equal(UUID);
       });
     });
     it('should test an ObjectID BSON type', () => {

--- a/test/lib/filtersSpec.js
+++ b/test/lib/filtersSpec.js
@@ -1,8 +1,30 @@
+import { Binary, ObjectId } from 'bson';
 import { expect } from 'chai';
+import { v4 as uuidv4 } from 'uuid';
 // eslint-disable-next-line camelcase
-import { to_display } from '../../lib/filters.js';
+import { stringDocIDs, to_display } from '../../lib/filters.js';
 
 describe('filters', function () {
+  describe('stringDocIDs', function () {
+    describe('should test a Binary BSON type', () => {
+      it('not v4');
+      it('v4', () => {
+        const UUID = uuidv4();
+        const hex = UUID.split('-').join('');
+        const buffer = new Buffer.from(hex, 'hex');
+        const input = new Binary(buffer, Binary.SUBTYPE_UUID);
+        expect(stringDocIDs(input)).to.equal(`UUID("${UUID}")`);
+      });
+    });
+    it('should test an ObjectID BSON type', () => {
+      const input = new ObjectId();
+      expect(stringDocIDs(input)).to.equal(input.toString());
+    });
+    it('should test a not BSON type', () => {
+      const input = {};
+      expect(stringDocIDs(input)).to.equal(input);
+    });
+  });
   describe('to_display', function () {
     it('should escape properly a string', () => {
       const result = to_display('<script>window.alert(\'alert 1!\')</script>');

--- a/test/lib/filtersSpec.js
+++ b/test/lib/filtersSpec.js
@@ -1,6 +1,5 @@
-import { Binary, ObjectId } from 'bson';
+import { Binary, ObjectId, UUID } from 'bson';
 import { expect } from 'chai';
-import { v4 as uuidv4 } from 'uuid';
 // eslint-disable-next-line camelcase
 import { stringDocIDs, to_display } from '../../lib/filters.js';
 
@@ -9,11 +8,11 @@ describe('filters', function () {
     describe('should test a Binary BSON type', () => {
       it('not v4');
       it('v4', () => {
-        const UUID = uuidv4();
-        const hex = UUID.split('-').join('');
+        const uuid = new UUID().toString();
+        const hex = uuid.split('-').join('');
         const buffer = new Buffer.from(hex, 'hex');
         const input = new Binary(buffer, Binary.SUBTYPE_UUID);
-        expect(stringDocIDs(input)).to.equal(UUID);
+        expect(stringDocIDs(input)).to.equal(uuid);
       });
     });
     it('should test an ObjectID BSON type', () => {

--- a/test/lib/routers/documentSpec.js
+++ b/test/lib/routers/documentSpec.js
@@ -1,4 +1,4 @@
-import { Binary } from 'bson';
+import { Binary, ObjectId, UUID } from 'bson';
 import { expect } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -44,7 +44,38 @@ describe('Router document', () => {
       .finally(() => testCollection(db).deleteOne({ _id }));
   });
 
-  it('POST /db/<dbName>/<collection> should add a new document');
+  describe('POST /db/<dbName>/<collection> should add a new document', () => {
+    it('ObjectId()', async () => {
+      const testValue = 'ObjectId()';
+      await request.post(`/db/${dbName}/${urlColName}`).send({ document: `{_id:ObjectId(),testValue:"${testValue}"}` }).expect(302);
+      const result = await testCollection(db).findOne({ testValue });
+      expect(result).to.not.equal({ _id: result._id, testValue });
+      expect(ObjectId.isValid(result._id.toString())).to.equal(true);
+      await testCollection(db).deleteOne({ _id: result._id });
+    });
+    it('ObjectId(<object_id>)', async () => {
+      const testValue = new ObjectId();
+      await request.post(`/db/${dbName}/${urlColName}`).send({ document: `{_id:ObjectId("${testValue}"),testValue:"${testValue}"}` }).expect(302);
+      const result = await testCollection(db).findOne({ testValue: testValue.toString() });
+      expect(ObjectId.isValid(result._id.toString())).to.equal(true);
+      await testCollection(db).deleteOne({ _id: result._id });
+    });
+    it('UUID()', async () => {
+      const testValue = 'UUID()';
+      await request.post(`/db/${dbName}/${urlColName}`).send({ document: `{_id:UUID(),testValue:"${testValue}"}` }).expect(302);
+      const result = await testCollection(db).findOne({ testValue });
+      expect(UUID.isValid(result._id.toString())).to.equal(true);
+      await testCollection(db).deleteOne({ _id: result._id });
+    });
+    it('UUID(<uuid>)', async () => {
+      const testUuid = new UUID();
+      const testValue = `UUID("${testUuid}")`;
+      await request.post(`/db/${dbName}/${urlColName}`).send({ document: `{_id:${testValue},testValue:${testValue}}` }).expect(302);
+      const result = await testCollection(db).findOne({ testValue: new UUID(testUuid) });
+      expect(UUID.isValid(result._id.toString())).to.equal(true);
+      await testCollection(db).deleteOne({ _id: result._id });
+    });
+  });
   it('DEL /db/<dbName>/<collection>/<document> should delete the document');
   it('PUT /db/<dbName>/<collection>/<document> should update the document');
 

--- a/test/lib/routers/documentSpec.js
+++ b/test/lib/routers/documentSpec.js
@@ -1,7 +1,5 @@
 import { Binary, ObjectId, UUID } from 'bson';
 import { expect } from 'chai';
-import { v4 as uuidv4 } from 'uuid';
-
 import { createServer, getDocumentUrl } from '../../testHttpUtils.js';
 import {
   cleanAndCloseDb, initializeDb, getFirstDocumentId, testDbName as dbName, testCollection, testURLCollectionName,
@@ -31,15 +29,15 @@ describe('Router document', () => {
       });
   });
   it('GET /db/<dbName>/<collection>/<document> (_id: UUID) should return html', async () => {
-    const UUID = uuidv4();
-    const hex = UUID.split('-').join('');
+    const uuid = new UUID().toString();
+    const hex = uuid.split('-').join('');
     const buffer = new Buffer.from(hex, 'hex');
     const _id = new Binary(buffer, Binary.SUBTYPE_UUID);
     const doc = { _id };
     await testCollection(db).insertOne(doc);
-    return request.get(getDocumentUrl(dbName, urlColName, UUID)).query({ subtype: Binary.SUBTYPE_UUID }).expect(200)
+    return request.get(getDocumentUrl(dbName, urlColName, uuid)).query({ subtype: Binary.SUBTYPE_UUID }).expect(200)
       .then((res) => {
-        expect(res.text).to.match(new RegExp(`<title>${UUID} - Mongo Express</title>`));
+        expect(res.text).to.match(new RegExp(`<title>${uuid} - Mongo Express</title>`));
       })
       .finally(() => testCollection(db).deleteOne({ _id }));
   });

--- a/test/lib/utilsSpec.js
+++ b/test/lib/utilsSpec.js
@@ -1,7 +1,15 @@
 import { expect } from 'chai';
-import { isValidDatabaseName } from '../../lib/utils.js';
+import { v4 as uuidv4 } from 'uuid';
+import { addHyphensToUUID, isValidDatabaseName } from '../../lib/utils.js';
 
 describe('utils', function () {
+  describe('addHyphensToUUID', function () {
+    it('should be valid', () => {
+      const UUID = uuidv4();
+      const hex = UUID.split('-').join('');
+      expect(addHyphensToUUID(hex)).to.equal(UUID);
+    });
+  });
   describe('isValidDatabaseName', function () {
     it('should be valid', () => {
       const validNames = [

--- a/test/lib/utilsSpec.js
+++ b/test/lib/utilsSpec.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
-import { v4 as uuidv4 } from 'uuid';
+import { UUID } from 'bson';
 import { addHyphensToUUID, isValidDatabaseName } from '../../lib/utils.js';
 
 describe('utils', function () {
   describe('addHyphensToUUID', function () {
     it('should be valid', () => {
-      const UUID = uuidv4();
-      const hex = UUID.split('-').join('');
-      expect(addHyphensToUUID(hex)).to.equal(UUID);
+      const uuid = new UUID().toString();
+      const hex = uuid.split('-').join('');
+      expect(addHyphensToUUID(hex)).to.equal(uuid);
     });
   });
   describe('isValidDatabaseName', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,6 +1382,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSONStream@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -1803,7 +1808,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1946,7 +1951,7 @@ chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1986,6 +1991,11 @@ chrome-trace-event@^1.0.2:
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
   dependencies:
     tslib "^1.9.0"
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 ci-info@^3.2.0, ci-info@^3.3.2:
   version "3.4.0"
@@ -2283,6 +2293,17 @@ cross-spawn@^5.0.1:
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -3251,6 +3272,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -3347,6 +3375,15 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -3559,7 +3596,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -3833,6 +3870,13 @@ is-callable@^1.2.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
 is-ci@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
@@ -3865,6 +3909,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
+
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -4021,6 +4070,13 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -4217,6 +4273,13 @@ json5@^2.1.2, json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -4245,6 +4308,13 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 lazy-ass@^1.6.0:
   version "1.6.0"
@@ -4491,6 +4561,14 @@ methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromatch@^4.0.2:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
 micromatch@^4.0.4:
   version "4.0.4"
@@ -4748,6 +4826,11 @@ next-tick@^1.1.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 node-html-parser@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.1.tgz#7f38f4427fafc242a22135d9db80c1455e837467"
@@ -4929,6 +5012,14 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -4945,6 +5036,11 @@ os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
   integrity sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 ospath@^1.2.2:
   version "1.2.2"
@@ -5042,6 +5138,25 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -5056,6 +5171,11 @@ path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -5113,6 +5233,11 @@ picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pify@^2.0.0, pify@^2.2.0:
   version "2.3.0"
@@ -5586,7 +5711,7 @@ schema-utils@^4.0.0:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.0.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -5726,6 +5851,11 @@ simple-update-notifier@^1.0.7:
   integrity sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==
   dependencies:
     semver "~7.0.0"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -6094,6 +6224,13 @@ timers-ext@^0.1.7:
     es5-ext "~0.10.46"
     next-tick "1"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmp@^0.2.1, tmp@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -6298,6 +6435,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 universalify@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6486,11 +6486,6 @@ uuid@^8.3.1, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/552)
---
<!-- Reviewable:end -->
This is a set of changes continuing on with the other changes that have been done for UUID support for IDs.  Specifically when a UUID is used for the _id field.  I only use BinData type 4 for my UUIDs, so that was all that I implemented and tested.

These changes make the list of documents in a collection show the UUIDs as human readable strings, rather than as base64 data.  These changes also support searching for documents by a UUID.

Please let me know what the minimal additional changes are that you would require to allow this to be pulled in to master.

Thanks

## TODO
- [x] Add hyphens to UUID in document detail (related https://github.com/mongodb-js/query-parser/issues/115)
  - Patched with `patch-package`
- [x] Handle new UUID with `UUID()` or `new UUID()` (related bug https://github.com/mongodb-js/query-parser/issues/114)
  - Patched with `patch-package`
- [x] Add unit tests