### PR TITLE
feat: add two tsl/ssl certificate-related options and adapted lib/db.js

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -64,6 +64,12 @@ const meConfigMongodbServer = process.env.ME_CONFIG_MONGODB_SERVER ?
 const sslCA = 'ME_CONFIG_MONGODB_CA_FILE';
 const sslCAFromEnv = getBinaryFileEnv(sslCA);
 
+const sslCert = 'ME_CONFIG_MONGODB_SSL_CERT_FILE';
+const sslCertFromEnv = getBinaryFileEnv(sslCert);
+
+const sslKey = 'ME_CONFIG_MONGODB_SSL_KEY_FILE';
+const sslKeyFromEnv = getBinaryFileEnv(sslKey);
+
 module.exports = {
   mongodb: {
     // if a connection string options such as server/port/etc are ignored
@@ -84,6 +90,12 @@ module.exports = {
 
     // sslCA: array of valid CA certificates
     sslCA: sslCAFromEnv ? [sslCAFromEnv] : [],
+
+    // sslCert: array of valid ssl certificates
+    sslCert: sslCertFromEnv ? [sslCertFromEnv] : [],
+
+    // sslKey: array of valid ssl keys
+    sslKey: sslKeyFromEnv ? [sslKeyFromEnv] : [],
 
     //autoReconnect: automatically reconnect if connection is lost
     autoReconnect: true,

--- a/lib/db.js
+++ b/lib/db.js
@@ -160,19 +160,21 @@ let connect = function (config) {
     }
   }
 
+  // connection options
+  let dbOptions = {
+    auto_reconnect: config.mongodb.autoReconnect,
+    poolSize:       config.mongodb.poolSize,
+    ssl:            config.mongodb.ssl == "true",  // is string
+    sslValidate:    config.mongodb.sslValidate == "true",  // is string
+    sslCA:          config.mongodb.sslCA.map(Object.values).map(Buffer.from),  // only works with buffer
+    sslCert:        config.mongodb.sslCert.map(Object.values).map(Buffer.from),  // only works with buffer
+    sslKey:         config.mongodb.sslKey.map(Object.values).map(Buffer.from),  // only works with buffer
+  };
+
   // database connection
   if (config.mongodb.connectionString) {
-    mongodb.MongoClient.connect(config.mongodb.connectionString, processOpenDatabase);
+    mongodb.MongoClient.connect(config.mongodb.connectionString, dbOptions, processOpenDatabase);
   } else {
-
-    // connection options
-    let dbOptions = {
-      auto_reconnect: config.mongodb.autoReconnect,
-      poolSize:       config.mongodb.poolSize,
-      ssl:            config.mongodb.ssl,
-      sslValidate:    config.mongodb.sslValidate,
-      sslCA:          config.mongodb.sslCA,
-    };
 
     // set up database using legacy configuration
     let host = config.mongodb.server  || 'localhost';


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/574)
---
<!-- Reviewable:end -->
This is rather a note or question than a true pull request. I don't understand much about encryption and nodejs, but I could not get the current mongo-express docker container (0.54) to connect to the latest official mongo container (4.2.6) with a SSL/TSL setup 

```
net:
  tls:
    mode: requireTLS
    certificateKeyFile: /run/secrets/tls_key_and_cert.pem
    CAFile: /run/secrets/tls_CA.pem

```

and self-signed certificates for testing purposes generated according to https://medium.com/@rajanmaharjan/secure-your-mongodb-connections-ssl-tls-92e2addb3c89 with

```bash
openssl genrsa -out rootCA.key 2048
openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.pem
openssl genrsa -out mongodb.key 2048
openssl req -new -key mongodb.key -out mongodb.csr
openssl x509 -req -in mongodb.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out mongodb.crt -days 500 -sha256
cat mongodb.key mongodb.crt > mongodb.pem 
```

without the code modifications demonstrated here. Otherwise, no SSL connection the the db server is established, probably due to some data type incompatibilities of passing strings and objects to mongodb.MongoClient within lib/db.js where boolean values and Buffers are expected (?).

Now, I have this setup working with this `docker-compose.yml` content:

```
version: '3.8'

services:
  mongodb:
    image: local_mongo
    restart: always
    build:
        context: ./compose/local/mongodb
        dockerfile: Dockerfile
    container_name: mongodb
    cap_add:
      - SYS_ADMIN
      - DAC_READ_SEARCH
    privileged: True
    expose:
      - 21017
    environment:
      MONGO_INITDB_ROOT_USERNAME_FILE: /run/secrets/mongo_root_username
      MONGO_INITDB_ROOT_PASSWORD_FILE: /run/secrets/mongo_root_password
    secrets:
      - smbcredentials
      - mongo_root_username
      - mongo_root_password
      - tls_key_and_cert.pem
      - tls_CA.pem
    command: --config /etc/mongod.conf

  mongo-express:
    image: mongo-express:latest
    restart: always
    ports:
      - 8081:8081
    depends_on:
      - mongodb
    environment:
      ME_CONFIG_MONGODB_SERVER: mongodb
      ME_CONFIG_MONGODB_SSL: "true"
      ME_CONFIG_MONGODB_SSLVALIDATE: "false"
      ME_CONFIG_MONGODB_SSL_CERT_FILE: /run/secrets/tls_cert.pem
      ME_CONFIG_MONGODB_SSL_KEY_FILE: /run/secrets/tls_key.pem
      ME_CONFIG_SITE_SSL_ENABLED: "true"
      ME_CONFIG_SITE_SSL_KEY_PATH: /run/secrets/tls_key.pem
      ME_CONFIG_SITE_SSL_CRT_PATH: /run/secrets/tls_cert.pem
      ME_CONFIG_MONGODB_ADMINUSERNAME_FILE: /run/secrets/mongo_root_username
      ME_CONFIG_MONGODB_ADMINPASSWORD_FILE: /run/secrets/mongo_root_password
    secrets:
      - mongo_root_username
      - mongo_root_password
      - tls_key.pem
      - tls_cert.pem

secrets:
  smbcredentials: 
    file: ./secrets/smbcredentials
  mongo_root_username: 
    file: ./secrets/mongo_root_username
  mongo_root_password: 
    file: ./secrets/mongo_root_password  
  tls_key.pem:
    file: ./keys/mongodb.key
  tls_cert.pem:
    file: ./keys/mongodb.crt
  tls_key_and_cert.pem: 
    file: ./keys/mongodb.pem
  tls_CA.pem: 
    file: ./keys/rootCA.pem
```
(note: the `local_mongo` image is just a thin modification to the official mongo image that mounts an smb share, nothing to do with the issue discussed here)

Where would those described type incompatibilities arise? Did I do something wrong, and would there be any better practice that avoids my modifications? 

References:
https://stackoverflow.com/questions/24381561/connecting-to-mongodb-over-ssl-with-node-js
https://stackoverflow.com/questions/28106940/mongodb-and-nodejs-ssl-secure-connection