### PR TITLE
Use ".csv" extension on CSV exports

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -366,7 +366,8 @@ var routes = function (config) {
     req.collection.find(query, projection, query_options).toArray(function (err, items) {
       res.setHeader(
         'Content-Disposition',
-        'attachment; filename="' + encodeURI(req.collectionName) + '"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)
+        'attachment; filename="' + encodeURI(req.collectionName) + '.csv"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)
+        + '.csv'
       );
       res.setHeader('Content-Type', 'text/csv');
       res.write(csv(items));


### PR DESCRIPTION
Just being practical. 

Tested on Ubuntu 20.04/Chrome 83