### PR TITLE
Fix loadDocument() when current URL has a query string

### DIFF
--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -103,7 +103,7 @@ function makeCollectionUrl() {
 window.loadDocument = function (url) {
   const selection = window.getSelection().toString();
   if (selection === '') {
-    window.location.href = url;
+    window.location.href = `${window.location.href.replace(window.location.search, '')}/${url}`;
   }
 };
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/580)
---
<!-- Reviewable:end -->
When on a collection and URL has a query string, clicking on a document to edit it doesn't work, because the document ID is concatenated at the end of the URL without cleaning it.

For instance: https://myserver/db/adplatform/mycollection?skip=10&key=&value=&type=&query=&projection=/%2254ee810375732d62e91a0000%22

While it should be https://myserver/db/adplatform/mycollection/%2254ee810375732d62e91a0000%22