### PR TITLE
Update/simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM node:18-alpine3.16
 
-# grab tini for signal processing and zombie killing
-RUN apk -U add --no-cache bash tini
-
-EXPOSE 8081
-
 # "localhost" doesn't mean much in a container, so we adjust our default to the common service name "mongo" instead
 # (and make sure the server listens outside the container, since "localhost" inside the container is usually difficult to access)
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
@@ -13,7 +8,13 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
 
 WORKDIR /opt/mongo-express
 COPY . .
-RUN yarn install
-# RUN yarn run build	# prepublish already run build
 
+RUN apk -U add --no-cache \
+        bash \
+        # grab tini for signal processing and zombie killing
+        tini \
+    && yarn install
+    # && yarn run build     # prepublish already run build
+
+EXPOSE 8081
 CMD ["/sbin/tini", "--", "yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,21 @@
 FROM node:18.7.0-slim
 
 # grab tini for signal processing and zombie killing
-ENV TINI_VERSION 0.9.0
-RUN set -x \
-	&& apt-get update && apt-get install -y ca-certificates curl \
-		--no-install-recommends \
-	&& apt-get install -y gpg \
-	&& curl -fSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini" -o /usr/local/bin/tini \
-	&& curl -fSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini.asc" -o /usr/local/bin/tini.asc \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& key=6380DC428747F6C393FEACA59A84159D7001A4E5 \
-	&& ( gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$key" || gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" ) \
-	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
-	&& chmod +x /usr/local/bin/tini \
-	&& tini -h \
-	&& apt-get purge --auto-remove -y ca-certificates curl \
-	&& rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends tini; \
+	rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8081
 
-# override some config defaults with values that will work better for docker
-ENV ME_CONFIG_EDITORTHEME="default" \
-    ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
-    ME_CONFIG_MONGODB_ENABLE_ADMIN="true" \
-    ME_CONFIG_BASICAUTH_USERNAME="" \
-    ME_CONFIG_BASICAUTH_PASSWORD="" \
-    ME_CONFIG_BASICAUTH_USERNAME_FILE="" \
-    ME_CONFIG_BASICAUTH_PASSWORD_FILE="" \
-    ME_CONFIG_MONGODB_ADMINUSERNAME_FILE="" \
-    ME_CONFIG_MONGODB_ADMINPASSWORD_FILE="" \
-    ME_CONFIG_MONGODB_AUTH_USERNAME_FILE="" \
-    ME_CONFIG_MONGODB_AUTH_PASSWORD_FILE="" \
-    ME_CONFIG_MONGODB_CA_FILE="" \
+# "localhost" doesn't mean much in a container, so we adjust our default to the common service name "mongo" instead
+# (and make sure the server listens outside the container, since "localhost" inside the container is usually difficult to access)
+ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     VCAP_APP_HOST="0.0.0.0"
 
-WORKDIR /app
+WORKDIR /opt/mongo-express
+COPY . .
+RUN yarn install
+RUN yarn run build
 
-COPY . /app
-
-RUN cp config.default.js config.js
-
-RUN set -x \
-	&& apt-get update && apt-get install -y git --no-install-recommends \
-	&& npm install \
-	&& apt-get purge --auto-remove -y git \
-	&& rm -rf /var/lib/apt/lists/*
-
-RUN npm run build
-
-CMD ["tini", "--", "npm", "start"]
+CMD ["tini", "--", "yarn", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ EXPOSE 8081
 # "localhost" doesn't mean much in a container, so we adjust our default to the common service name "mongo" instead
 # (and make sure the server listens outside the container, since "localhost" inside the container is usually difficult to access)
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
+    ME_CONFIG_MONGODB_ENABLE_ADMIN="true" \
     VCAP_APP_HOST="0.0.0.0"
 
 WORKDIR /opt/mongo-express

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM node:18.7.0-slim
+FROM node:18-alpine3.16
 
 # grab tini for signal processing and zombie killing
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends tini; \
-	rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash tini
 
 EXPOSE 8081
 
@@ -19,4 +16,4 @@ COPY . .
 RUN yarn install
 RUN yarn run build
 
-CMD ["tini", "--", "yarn", "run", "start"]
+CMD ["/sbin/tini", "--", "yarn", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
 WORKDIR /opt/mongo-express
 COPY . .
 RUN yarn install
-RUN yarn run build
+# RUN yarn run build	# prepublish already run build
 
 CMD ["/sbin/tini", "--", "yarn", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY . .
 RUN yarn install
 # RUN yarn run build	# prepublish already run build
 
-CMD ["/sbin/tini", "--", "yarn", "run", "start"]
+CMD ["/sbin/tini", "--", "yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine3.16
 
 # grab tini for signal processing and zombie killing
-RUN apk add --no-cache bash tini
+RUN apk -U add --no-cache bash tini
 
 EXPOSE 8081
 


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/583)
---
<!-- Reviewable:end -->
This updates the Dockerfile to explicitly build from the "Debian Buster" slim variant of the Node.js official image, and trims down the set of overridden environment variables.

This also updates from "npm" to "yarn" and changes to installing "tini" from Debian instead of downloading it by hand.

I can't currently test this successfully due to https://github.com/mongo-express/mongo-express/issues/581, but I have verified that it builds successfully (which is more than can be said for what currently exists in master, since `node:12-slim` updated to be based on `debian:buster` instead of `debian:stretch` and thus no longer has `gpg` installed).

If we can figure out what's causing https://github.com/mongo-express/mongo-express/issues/581 and this needs changes, I'll happily apply them. :smile:

As always, happy to rebase/amend/adjust/close as desired. :+1:

---

Fix #842