### PR TITLE
Disable delete actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
     `ME_CONFIG_OPTIONS_EDITORTHEME`   | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
     `ME_CONFIG_OPTIONS_READONLY`      | `false`         | if readOnly is true, components of writing are not visible.
+    `ME_CONFIG_OPTIONS_NO_DELETE`      | `false`         | if noDelete is true, components of deleting are not visible.
     `ME_CONFIG_SITE_SSL_ENABLED`      | `false`         | Enable SSL.
     `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
     `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.

--- a/config.default.js
+++ b/config.default.js
@@ -193,6 +193,9 @@ module.exports = {
 
     // noExport: if noExport is set to true, we won't show export buttons
     noExport: false,
+
+    // noDelete: if noDelete is set to true, we won't show delete buttons
+    noDelete: process.env.ME_CONFIG_OPTIONS_NO_DELETE || false,
   },
 
   // Specify the default keyname that should be picked from a document to display in collections list.

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -41,6 +41,7 @@ const middleware = async function (config) {
   app.set('me_collapsible_json_default_unfold', config.options.collapsibleJSONDefaultUnfold || false);
   app.set('me_no_export', config.options.noExport || false);
   app.set('gridFSEnabled', config.options.gridFSEnabled || false);
+  app.set('no_delete', config.options.noDelete || false);
 
   return app;
 };

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -446,6 +446,10 @@ var routes = function (config) {
       req.session.error = 'Error: config.options.readOnly is set to true';
       return res.redirect('back');
     }
+    if (config.options.noDelete === true) {
+      req.session.error = 'Error: config.options.noDelete is set to true';
+      return res.redirect('back');
+    }
     var query = exp._buildMongoQuery(req);
     if (query) {
       // we're just deleting some of the documents
@@ -527,6 +531,10 @@ var routes = function (config) {
     }
     if (config.options.readOnly === true) {
       req.session.error = 'Error: config.options.readOnly is set to true';
+      return res.redirect('back');
+    }
+    if (config.options.noDelete === true) {
+      req.session.error = 'Error: config.options.noDelete is set to true';
       return res.redirect('back');
     }
     req.collection.dropIndex(req.query.name, function (err) {

--- a/lib/scripts/document.js
+++ b/lib/scripts/document.js
@@ -11,6 +11,7 @@ const doc = CodeMirror.fromTextArea(document.getElementById('document'), {
   autoClearEmptyLines: true,
   matchBrackets: true,
   readOnly: ME_SETTINGS.readOnly,
+  noDelete: ME_SETTINGS.noDelete,
   theme: ME_SETTINGS.codeMirrorEditorTheme,
 });
 

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -135,7 +135,7 @@
       </form>
     </div>
   </div>
-  {% if !settings.read_only && count > 0 %}
+  {% if !settings.read_only && !settings.no_delete && count > 0 %}
   <p>
     <form id="deleteListForm" method="POST" style="display:inline;" action="{{ collectionUrl }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query|default('{}') }}&projection={{ projection }}">
       {# Router is smart enough to transform method=POST + _method=delete into actual HTTP DELETE, which is what we want #}
@@ -262,7 +262,7 @@
         {% endif %}
           {% for column in columns %}
             <td><div class="tableContent">
-              {% if !settings.read_only && column === '_id' && collectionName !== 'system.indexes' %}
+              {% if !settings.read_only && !settings.no_delete && column === '_id' && collectionName !== 'system.indexes' %}
                 <form class="deleteButtonDocument" method="POST" style="display:inline;" action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?skip={{ skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection= {{ projection }}">
                 <input type="hidden" name="_method" value="delete">
                 <button type="submit" class="btn btn-danger">
@@ -386,6 +386,7 @@
           </a>
         </div>
       </div>
+    {% if !settings.no_delete %}
       <div class="col-sm-4">
         <form method="POST" action="{{ collectionUrl }}" class="well">
         <form method="POST" action="{{ baseHref }}db/{{ dbName }}/{{ collectionName | url_encode }}" id="db-{{ dbName }}-{{ collectionName }}" class="well">
@@ -451,6 +452,7 @@
           </div>
         </div>
       </div>
+    {% endif %}
     {% endif %}
 
   <div class="stats col-md-12">
@@ -551,7 +553,7 @@
           <div>{% if k != 'key' && k != 'v' && k != 'name' && k != 'ns' && k != 'size'%} {{ k }}: &nbsp;{{ v }} {% endif %}</div>
           {% endfor %}
         </td>
-      {% if !settings.read_only %}
+      {% if !settings.read_only && !settings.no_delete %}
         <td>
           <a class="btn btn-danger" href="{{ dbUrl }}/dropIndex/{{ collectionName | url_encode }}?name={{ index.name }}">
             <span class="glyphicon glyphicon-trash"></span> &nbsp;DEL

--- a/lib/views/database.html
+++ b/lib/views/database.html
@@ -65,7 +65,7 @@
           <input class="input-hidden import-input-file" type="file" name="import-file" collection-name="{{ c | url_encode }}"/>
         </td>
         <td><h3><a href="{{ dbUrl }}/{{ c | url_encode }}">{{ c }}</a></h3></td>
-        {% if !settings.read_only %}
+        {% if !settings.read_only && !settings.no_delete %}
         <td class="col-md-1">
           <form method="POST"
             action="{{ dbUrl }}/{{ c | url_encode }}"

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -117,7 +117,7 @@
   </div>
 </form>
 
-{% if !settings.read_only %}
+{% if !settings.read_only && !settings.no_delete %}
   <br>
 
   {% if document._id._bsontype == 'Binary' %}

--- a/lib/views/gridfs.html
+++ b/lib/views/gridfs.html
@@ -51,7 +51,7 @@
         {% for column in columns %}
           <td><div class="tableContent">{{ file[column] | to_display | safe }}</div></td>
         {% endfor %}
-          {% if !settings.read_only %}
+          {% if !settings.read_only && !settings.no_delete %}
             <td>
               <div class="col-md-1">
                 <form method="POST" action="{{ dbUrl }}/gridFS/{{ bucketName }}/{{ file._id | json | safe | url_encode }}">

--- a/lib/views/index.html
+++ b/lib/views/index.html
@@ -44,7 +44,7 @@
       </a>
     </td>
     <td><h3><a href="{{ baseHref }}db/{{ db | url_encode }}/">{{ db }}</a></h3></td>
-    {% if !settings.read_only %}
+    {% if !settings.read_only && !settings.no_delete %}
     <td class="col-md-2">
       <form method="POST" action="{{ baseHref }}{{ db | url_encode }}" style="margin: 0px;">
         <input type="hidden" name="_method" value="delete">
@@ -60,7 +60,7 @@
 </table>
 </div>
   </div>
-{% if !settings.read_only %}
+{% if !settings.read_only && !settings.no_delete %}
 <div id="confirm-deletion" class="modal fade" role="dialog" aria-labelledby="confirmDeletionLabel">
   <div class="modal-dialog" role="document">
     <div class="modal-content">

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -99,6 +99,7 @@
 'use strict';
 window.ME_SETTINGS = {
   readOnly: '{{ !!settings.read_only }}' === 'true',
+  noDelete: '{{ !!settings.no_delete }}' === 'true',
   codeMirrorEditorTheme: '{{ editorTheme }}',
   baseHref: '{{ baseHref }}',
   collapsibleJSON: '{{ !!settings.me_collapsible_json }}' === 'true',


### PR DESCRIPTION
I had an internal user request the ability to disable the delete actions but still be able to create/update/export.

I implemented it by copying the way `readOnly` is implemented and made sure that all sections with  `glyphicon-trash`  had  an `if` block around them.

Tested by hand with 

```
# .env
ME_CONFIG_MONGODB_URL=mongodb://mongo:27017/demo-db
VCAP_APP_HOST=0.0.0.0
ME_CONFIG_OPTIONS_NO_DELETE=true
```

and

```yaml
# docker-compose.yml
version: '2.4'
networks:
  main:
services:
  mongo:
    image: mongo
    restart: always
    env_file:
      - .env
    networks:
      - main
    volumes:
      - ./mongo_data:/data/db
  mongo-express:
    image: node:12
    working_dir: /home/node/app
    env_file:
      - .env
    command: 
      - /bin/bash
      - -c
      - |
        npm install
        npm run start-dev
    volumes:
      - ./:/home/node/app
    ports:
      - 8081:8081
    networks:
      - main
```

