### PR TITLE
Added support for running raw commands on a collection

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
     "prefer-const": ["off"],
     "object-shorthand": ["off"],
     "no-path-concat": ["off"],
+    "no-eval": ["off"],
     "no-shadow": ["off", {allow: ["err", "error"]}],
     "camelcase": ["off"],
   },

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
     `ME_CONFIG_OPTIONS_EDITORTHEME`   | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
     `ME_CONFIG_OPTIONS_READONLY`      | `false`         | if readOnly is true, components of writing are not visible.
-    `ME_CONFIG_OPTIONS_NO_DELETE`      | `false`         | if noDelete is true, components of deleting are not visible.
+    `ME_CONFIG_OPTIONS_NO_DELETE`     | `false`         | if noDelete is true, components of deleting are not visible.
+    `ME_CONFIG_OPTIONS_NO_RAW_COMMAND`| `false`         | if noRawCommand is true, the Raw tab in collection view is not visible.
     `ME_CONFIG_SITE_SSL_ENABLED`      | `false`         | Enable SSL.
     `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
     `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.

--- a/config.default.js
+++ b/config.default.js
@@ -200,6 +200,8 @@ module.exports = {
 
     // noDelete: if noDelete is set to true, we won't show delete buttons
     noDelete: process.env.ME_CONFIG_OPTIONS_NO_DELETE || false,
+
+    noRawCommand: process.env.ME_CONFIG_OPTIONS_NO_RAW_COMMAND ? process.env.ME_CONFIG_OPTIONS_NO_RAW_COMMAND.toLowerCase() === 'true' : false,
   },
 
   // Specify the default keyname that should be picked from a document to display in collections list.

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -42,6 +42,7 @@ const middleware = async function (config) {
   app.set('me_no_export', config.options.noExport || false);
   app.set('gridFSEnabled', config.options.gridFSEnabled || false);
   app.set('no_delete', config.options.noDelete || false);
+  app.set('no_raw_command', config.options.noRawCommand || false);
 
   return app;
 };

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -122,6 +122,43 @@ var routes = function (config) {
   exp.viewCollection = function (req, res) {
     req.query = req.query || {}; // might not be present in Express5
 
+    if (req.query.command) {
+      try {
+        const match = /^(.*?)\s*\((.*)\)\s*$/.exec(req.query.command);
+        if (!match || !match.length >= 3) {
+          req.session.error = 'Invalid command. Example: updateOne({myproperty:"someValue"}, {$set:{myproperty:"someOtherValue"}})';
+          return res.redirect('back');
+        }
+
+        const fun = match[1];
+        if (typeof req.collection[fun] === 'function') {
+          const args = match[2].split(',').map(s => eval(`(${s})`));
+          return req.collection[fun](...args, async function (err, result) {
+            if (err) {
+              req.session.error = err.message;
+              return res.redirect('back');
+            }
+            try {
+              if (result.toArray) {
+                result = await result.toArray();
+              }
+              req.session.success = JSON.stringify(result, null, 2);
+            } catch (e) {
+              console.error(e);
+              req.session.success = 'Command succeeded, but unable to parse the result';
+            }
+            return res.redirect('back');
+          });
+        } else {
+          req.session.error = `Invalid function: ${fun}`;
+          return res.redirect('back');
+        }
+      } catch (err) {
+        console.error(err);
+        req.session.error = 'Invalid command\nExample command: updateOne({myproperty:"someValue"}, {$set:{myproperty:"someOtherValue"}})';
+        return res.redirect('back');
+      }
+    }
     var query;
     var query_options;
     var projection;

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -81,6 +81,9 @@
   <ul id="tabs" class="nav nav-pills nav-justified" data-tabs="tabs">
     <li class="active"><a href="#simple" data-toggle="tab"><span class="glyphicon glyphicon-tag"></span>  Simple</a></li>
     <li><a href="#advanced" data-toggle="tab"><span class="glyphicon glyphicon-tags"></span>  Advanced</a></li>
+    {% if !settings.read_only && !settings.no_raw_command %}
+    <li><a href="#raw" data-toggle="tab"><span class="glyphicon glyphicon-play"></span>  Raw</a></li>
+    {% endif %}
   </ul>
   <div id="my-tab-content" class="tab-content">
     <div class="tab-pane active" id="simple">
@@ -129,6 +132,24 @@
             <button style="height:150px;" type="submit" class="btn btn-primary btn-block">
               <span class="glyphicon glyphicon-search"></span>
             Find
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane" id="raw">
+      <form class="well" method="get" action="{{ collectionUrl }}">
+        {% for column in columns %}
+        <input type="checkbox" name="sort[{{column}}]" class="hide sort-{{column}}" {% if sort[column] %}value="{{sort[column]}}" checked="checked"{% endif %}/>
+        {% endfor %}
+        <div class="row">
+          <div class="form-group col-sm-12 col-md-10">
+            <textarea class="input-medium form-control" style="width: 100%; height: 150px" id="command" name="command" placeholder="Command" title="Command">{{ command }}</textarea>
+          </div>
+          <div class="form-group col-md-2">
+            <button style="height:150px;" type="submit" class="btn btn-primary btn-block">
+              <span class="glyphicon glyphicon-play"></span>
+              Run
             </button>
           </div>
         </div>

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -100,6 +100,7 @@
 window.ME_SETTINGS = {
   readOnly: '{{ !!settings.read_only }}' === 'true',
   noDelete: '{{ !!settings.no_delete }}' === 'true',
+  noRawCommand: '{{ !!settings.no_raw_command }}' === 'true',
   codeMirrorEditorTheme: '{{ editorTheme }}',
   baseHref: '{{ baseHref }}',
   collapsibleJSON: '{{ !!settings.me_collapsible_json }}' === 'true',


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/613)
---
<!-- Reviewable:end -->
Thanks for this great tool! A feature I've been missing for a while is to be able to run raw commands on a collection. To e.g. updateMany etc. I didn't dive deep into the sctructure of the app, so I might not have implemented it ideally but it works :)

This PR creates a new Tab in the collection view where the user can run raw commands. Syntax in the input field would be like: updateMany({myproperty:"someValue"}, {$set:{myproperty:"someOtherValue"}})

The tab is hidden if either ME_CONFIG_OPTIONS_NO_RAW_COMMAND or ME_CONFIG_OPTIONS_READONLY is set to true