### PR TITLE
Fix query options bug from Mongodb breaking change

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -93,16 +93,12 @@ var routes = function (config) {
   };
 
   exp._getQueryOptions = function (req) {
-    var limit = config.options.documentsPerPage;
-    var skip = parseInt(req.query.skip, 10) || 0;
-    var sort = exp._getSort(req);
-
-    var query_options = {
-      sort:   sort,
-      limit:  limit,
-      skip:   skip,
+    return {
+      sort:  exp._getSort(req),
+      limit: config.options.documentsPerPage,
+      skip: parseInt(req.query.skip, 10) || 0,
+      projection: exp._getProjection(req),
     };
-    return query_options;
   };
 
   exp._getProjection = function (req) {
@@ -124,11 +120,9 @@ var routes = function (config) {
 
     var query;
     var query_options;
-    var projection;
     try {
       query = exp._getQuery(req, res);
       query_options = exp._getQueryOptions(req);
-      projection = exp._getProjection(req, res);
     } catch (err) {
       req.session.error = err.message;
       return res.redirect('back');
@@ -155,7 +149,7 @@ var routes = function (config) {
     var limit = query_options.limit;
     var sort = query_options.sort;
 
-    req.collection.find(query, projection, query_options).toArray(function (err, items) {
+    req.collection.find(query, query_options).toArray(function (err, items) {
       req.collection.stats(function (err, stats) {
         if (stats === undefined) {
           req.session.error = 'Collection not found!';
@@ -301,20 +295,18 @@ var routes = function (config) {
 
     var query;
     var query_options;
-    var projection;
 
     try {
       query_options = {
         sort: exp._getSort(req),
       };
       query = exp._getQuery(req, res);
-      projection = exp._getProjection(req, res);
     } catch (err) {
       req.session.error = err.message;
       return res.redirect('back');
     }
 
-    req.collection.find(query, projection, query_options).stream({
+    req.collection.find(query, query_options).stream({
       transform: function (item) {
         return bson.toJsonString(item) + os.EOL;
       },
@@ -324,20 +316,18 @@ var routes = function (config) {
   exp.exportColArray = function (req, res) {
     var query;
     var query_options;
-    var projection;
 
     try {
       query_options = {
         sort: exp._getSort(req),
       };
       query = exp._getQuery(req, res);
-      projection = exp._getProjection(req, res);
     } catch (err) {
       req.session.error = err.message;
       return res.redirect('back');
     }
 
-    req.collection.find(query, projection, query_options).toArray(function (err, items) {
+    req.collection.find(query, query_options).toArray(function (err, items) {
       res.setHeader(
         'Content-Disposition',
         'attachment; filename="' + encodeURI(req.collectionName) + '"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)
@@ -351,20 +341,18 @@ var routes = function (config) {
   exp.exportCsv = function (req, res) {
     var query;
     var query_options;
-    var projection;
 
     try {
       query_options = {
         sort: exp._getSort(req),
       };
       query = exp._getQuery(req, res);
-      projection = exp._getProjection(req, res);
     } catch (err) {
       req.session.error = err.message;
       return res.redirect('back');
     }
 
-    req.collection.find(query, projection, query_options).toArray(function (err, items) {
+    req.collection.find(query, query_options).toArray(function (err, items) {
       res.setHeader(
         'Content-Disposition',
         'attachment; filename="' + encodeURI(req.collectionName) + '.csv"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)


### PR DESCRIPTION
The PR: #558 updated mongodb version from `2.2.24` to `3.5.5`. There are some breaking changes in mongodb 3.x.x version like [find](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CHANGES_3.0.0.md#find) which removed the projection field as separate parameters and expectes it in options.  
Since projection was the second field and query_options was the third one, all features like sorting and pagination were corrupted by the update. This PR will fix this issue.