### PR TITLE
Fixed Issue #590: docker build fails, gpg not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV TINI_VERSION 0.9.0
 RUN set -x \
 	&& apt-get update && apt-get install -y ca-certificates curl \
 		--no-install-recommends \
+	&& apt-get install -y gpg \
 	&& curl -fSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini" -o /usr/local/bin/tini \
 	&& curl -fSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini.asc" -o /usr/local/bin/tini.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
Fixes #590 .

Docker build fails with a `gpg: not found`, so installing `gpg` before calling it.