### PR TITLE
Fix SSL env variable config and unifiedTopology

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -98,7 +98,7 @@ const connectionOptions = {
 
   // poolSize: size of connection pool (number of connections to use)
   poolSize: 4,
-}
+};
 
 // Unified topology server discovery engine does not support auto reconnect
 if (process.env.ME_CONFIG_MONGODB_UNIFIEDTOPOLOGY === 'true') {

--- a/config.default.js
+++ b/config.default.js
@@ -86,12 +86,12 @@ const sslCAFromEnv = getBinaryFileEnv(sslCA);
 
 const connectionOptions = {
   // ssl: connect to the server using secure SSL
-  ssl: process.env.ME_CONFIG_MONGODB_SSL ?
-    process.env.ME_CONFIG_MONGODB_SSL === 'true' : mongo.ssl,
+  ssl: process.env.ME_CONFIG_MONGODB_SSL
+    ? process.env.ME_CONFIG_MONGODB_SSL === 'true' : mongo.ssl,
 
   // sslValidate: validate mongod server certificate against CA
-  sslValidate: process.env.ME_CONFIG_MONGODB_SSLVALIDATE ?
-    process.env.ME_CONFIG_MONGODB_SSLVALIDATE === 'true' : true,
+  sslValidate: process.env.ME_CONFIG_MONGODB_SSLVALIDATE
+    ? process.env.ME_CONFIG_MONGODB_SSLVALIDATE === 'true' : true,
 
   // sslCA: array of valid CA certificates
   sslCA: sslCAFromEnv ? [sslCAFromEnv] : null,
@@ -102,10 +102,10 @@ const connectionOptions = {
 
 // Unified topology server discovery engine does not support auto reconnect
 if (process.env.ME_CONFIG_MONGODB_UNIFIEDTOPOLOGY === 'true') {
-  connectionOptions.useUnifiedTopology = true
-  connectionOptions.autoReconnect = false
+  connectionOptions.useUnifiedTopology = true;
+  connectionOptions.autoReconnect = false;
 } else {
-  connectionOptions.autoReconnect = true
+  connectionOptions.autoReconnect = true;
 }
 
 module.exports = {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/677)
---
<!-- Reviewable:end -->
SSL env variable was being passed as a string, which was invalid and always treated as false, even when set to "true".
sslCA was also set to `[]` by default, which happens to break SSL. Setting to null uses system defaults.

Tested on Atlas with the following

```
env \
ME_CONFIG_MONGODB_URL="mongodb+srv://td-adm:furehajabrolonifobefreri@tdps-db-1.vz0s6.gcp.mongodb.net/staging?retryWrites=true&w=majority" \
ME_CONFIG_MONGODB_SSL="true" \
ME_CONFIG_MONGODB_ENABLE_ADMIN="true" \
VCAP_APP_HOST="myhost.localhost" \
VCAP_APP_PORT="8443" \
ME_CONFIG_MONGODB_UNIFIEDTOPOLOGY="true" \
node mongo-express/app.js
```