### PR TITLE
Fix document delete on collection view for UUID (BinData 3 & 4)

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -263,7 +263,7 @@
           {% for column in columns %}
             <td><div class="tableContent">
               {% if !settings.read_only && !settings.no_delete && column === '_id' && collectionName !== 'system.indexes' %}
-                <form class="deleteButtonDocument" method="POST" style="display:inline;" action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?skip={{ skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection= {{ projection }}">
+                <form class="deleteButtonDocument" method="POST" style="display:inline;" action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}&skip={{ skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection= {{ projection }}">
                 <input type="hidden" name="_method" value="delete">
                 <button type="submit" class="btn btn-danger">
                 <span class="glyphicon glyphicon-trash"></span>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/704)
---
<!-- Reviewable:end -->
This will fix #668 

Request path is missing `subtype` param. Figured this after looking at this commit for reference https://github.com/mongo-express/mongo-express/pull/538/commits/760a14f5adc559577fa5e568b7a01aa1be8ea0e8

Turns out this issue had been fixed previously, but only in the individual document view and not the collection view.