### PR TITLE
Fix default config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 8081
 
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_EDITORTHEME="default" \
-    ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
+    ME_CONFIG_MONGODB_SERVER="mongo" \
     ME_CONFIG_MONGODB_ENABLE_ADMIN="true" \
     ME_CONFIG_BASICAUTH_USERNAME="" \
     ME_CONFIG_BASICAUTH_PASSWORD="" \


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/738)
---
<!-- Reviewable:end -->
When `ME_CONFIG_MONGODB_URL` is set, other envs will be ignored like `ME_CONFIG_MONGODB_PORT`, `ME_CONFIG_MONGODB_AUTH_DATABASE` etc.

So `ME_CONFIG_MONGODB_URL` should not set by default, is better to set by user.

Btw, mongo offical docker hub page used `mongo-express`, and it's example can't work now, this pr should fix this.

from [https://hub.docker.com/_/mongo](https://hub.docker.com/_/mongo)
```yml
# Use root/example as user/password credentials
version: '3.1'

services:

  mongo:
    image: mongo
    restart: always
    environment:
      MONGO_INITDB_ROOT_USERNAME: root
      MONGO_INITDB_ROOT_PASSWORD: example

  mongo-express:
    image: mongo-express
    restart: always
    ports:
      - 8081:8081
    environment:
      ME_CONFIG_MONGODB_ADMINUSERNAME: root
      ME_CONFIG_MONGODB_ADMINPASSWORD: example
```