### PR TITLE
Minor linting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Features
 Screenshots
 -----------
 
-Home Page | Database View | Collection View | Editing A Document
---- | --- | --- | ---
-<img src="http://i.imgur.com/XiYhblA.png" title="Home Page showing databases"> | <img src="http://i.imgur.com/XWcIgY1.png" title="Viewing collections & buckets in a database" /> | <img src="https://imgur.com/UmGSr3x.png" title="Viewing documents in a collection" /> | <img src="https://imgur.com/lL38abn.png" title="Editing a document" />
+| Home Page                                                                      | Database View                                                                                    | Collection View                                                                       | Editing A Document                                                     |
+|--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| <img src="http://i.imgur.com/XiYhblA.png" title="Home Page showing databases"> | <img src="http://i.imgur.com/XWcIgY1.png" title="Viewing collections & buckets in a database" /> | <img src="https://imgur.com/UmGSr3x.png" title="Viewing documents in a collection" /> | <img src="https://imgur.com/lL38abn.png" title="Editing a document" /> |
 
 These screenshots are from version 0.30.40
 View album for more screenshots: (server status, database views etc..)

--- a/config.default.js
+++ b/config.default.js
@@ -54,11 +54,6 @@ function getFileEnv(envVariable) {
   return origVar;
 }
 
-function getBinaryFileEnv(envVariable) {
-  const fileVar = process.env[envVariable];
-  return getFile(fileVar);
-}
-
 const meConfigMongodbServer = process.env.ME_CONFIG_MONGODB_SERVER
   ? process.env.ME_CONFIG_MONGODB_SERVER.split(',')
   : false;

--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -278,6 +278,7 @@ $(() => {
       contentType: false, // Set content type to false as jQuery will tell the server its a query string request
     })
       .done(function (res) {
+        // eslint-disable-next-line no-alert
         alert(res);
       });
   });

--- a/lib/scripts/database.js
+++ b/lib/scripts/database.js
@@ -64,6 +64,7 @@ $(() => {
       contentType: false, // Set content type to false as jQuery will tell the server its a query string request
     })
       .done(function (res) {
+        // eslint-disable-next-line no-alert
         alert(res);
       });
   });


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/852)
---
<!-- Reviewable:end -->
## Build errors/warnings

#815 introduced a [build error](https://github.com/mongo-express/mongo-express/actions/runs/2141750857) when removing the only use of `getBinaryFileEnv`.

![image](https://user-images.githubusercontent.com/3138467/169089803-82a22f17-1bc2-45c7-b576-113ab0afa969.png)

- getBinaryFileEnv resolves [build error](https://github.com/mongo-express/mongo-express/actions/runs/2141750857) 
- adding a lint ignore for intentional alerts resolves build warnings

## Jetbrains warning

- README.md change is a recommendation from WebStorm that is not different when rendered and easier to read raw
![image](https://user-images.githubusercontent.com/3138467/169089102-77a65d60-0bd0-4d8f-8d1e-c02248449932.png)