### PR TITLE
Rename depricated cloud foundry var "VCAP_APP_PORT" to "PORT"

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_SITE_SSL_KEY_PATH`     | ` `             | SSL key file.
     `ME_CONFIG_SITE_GRIDFS_ENABLED`   | `false`         | Enable gridFS to manage uploaded files.
     `VCAP_APP_HOST`                   | `localhost`     | address that mongo-express will listen on for incoming connections.
-    `VCAP_APP_PORT`                   | `8081`          | port that mongo-express will run on.
+    `PORT`                            | `8081`          | port that mongo-express will run on.
     `ME_CONFIG_MONGODB_CA_FILE`       | ``              | CA certificate File
     `ME_CONFIG_BASICAUTH_USERNAME_FILE`     | ``        | File version of ME_CONFIG_BASICAUTH_USERNAME
     `ME_CONFIG_BASICAUTH_PASSWORD_FILE`     | ``        | File version of ME_CONFIG_BASICAUTH_PASSWORD

--- a/config.default.js
+++ b/config.default.js
@@ -120,7 +120,7 @@ module.exports = {
     cookieKeyName: 'mongo-express',
     cookieSecret: process.env.ME_CONFIG_SITE_COOKIESECRET || 'cookiesecret',
     host: process.env.VCAP_APP_HOST || 'localhost',
-    port: process.env.VCAP_APP_PORT || 8081,
+    port: process.env.PORT || 8081,
     requestSizeLimit: process.env.ME_CONFIG_REQUEST_SIZE || '50mb',
     sessionSecret: process.env.ME_CONFIG_SITE_SESSIONSECRET || 'sessionsecret',
     sslCert: process.env.ME_CONFIG_SITE_SSL_CRT_PATH || '',


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/856)
---
<!-- Reviewable:end -->
Use naming convention of the environment variable $PORT for web application to bind its HTTP server. Cloud Foundry VCAP-APP-PORT [is depricated](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-APP-PORT)