### PR TITLE
Pin mongodb-query-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "~4.17.4",
     "method-override": "^2.3.10",
     "mongodb": "^3.6.2",
-    "mongodb-query-parser": "^2.1.2",
+    "mongodb-query-parser": "2.1.2",
     "morgan": "^1.9.0",
     "patch-package": "^6.4.7",
     "serve-favicon": "^2.5.0",


### PR DESCRIPTION
Hi, package install fails with error:
```
patch-package 6.4.7
Applying patches...

**ERROR** Failed to apply patch for package mongodb-query-parser at path
  
    node_modules/mongodb-query-parser

  This error was caused because mongodb-query-parser has changed since you
  made the patch file for it. This introduced conflicts with your patch,
  just like a merge conflict in Git when separate incompatible changes are
  made to the same piece of code.

  Maybe this means your patch file is no longer necessary, in which case
  hooray! Just delete it!

  Otherwise, you need to generate a new patch file.

  To generate a new one, just repeat the steps you made to generate the first
  one.

  i.e. manually make the appropriate file changes, then run 

    patch-package mongodb-query-parser

  Info:
    Patch file: patches/mongodb-query-parser+2.1.2.patch
    Patch was made for version: 2.1.2
    Installed version: 2.4.6

---
patch-package finished with 1 error(s).
```

I've pinned the target dependency.

relates to #810 #619 #846