### PR TITLE
Fix path glob resolution of webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,9 +84,9 @@ module.exports = {
         { from: 'public/stylesheets/*', to: 'css/[name][ext]' },
 
         { from: path.join(codemirrorPath, '/lib/codemirror.css'), to: 'css/[name][ext]' },
-        { from: path.join(codemirrorPath, '/theme/*'), to: 'css/theme/[name][ext]' },
+        { from: path.join(codemirrorPath, '/theme'), to: 'css/theme/[name][ext]' },
 
-        { from: path.join(bootstrapPath, '/dist/fonts/*'), to: 'fonts/[name][ext]' },
+        { from: path.join(bootstrapPath, '/dist/fonts'), to: 'fonts/[name][ext]' },
         { from: path.join(bootstrapPath, '/dist/css/bootstrap.min.css'), to: 'css/[name][ext]' },
         { from: path.join(bootstrapPath, '/dist/css/bootstrap.min.css.map'), to: 'css/[name][ext]' },
         { from: path.join(bootstrapPath, '/dist/css/bootstrap-theme.min.css'), to: 'css/[name][ext]' },


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/876)
- - -
<!-- Reviewable:end -->
Current output using _start-dev_ script to start:
```console
...
[1] modules by path ./node_modules/ 791 KiB
[1]   modules by path ./node_modules/bootstrap/ 73.6 KiB 13 modules
[1]   modules by path ./node_modules/codemirror/ 425 KiB
[1]     ./node_modules/codemirror/lib/codemirror.js 389 KiB [built] [code generated]
[1]     ./node_modules/codemirror/mode/javascript/javascript.js 37 KiB [built] [code generated]
[1]   ./node_modules/renderjson/renderjson.js 10.8 KiB [built] [code generated]
[1]   ./node_modules/jquery/dist/jquery.js 281 KiB [built] [code generated]
[1] modules by path ./lib/scripts/*.js 15.3 KiB 9 modules
[1]
[1] ERROR in unable to locate 'C:\workspace\mongo-express\node_modules\codemirror\theme\*' glob
[1]
[1] ERROR in unable to locate 'C:\workspace\mongo-express\node_modules\bootstrap\dist\fonts\*' glob
```