### PR TITLE
Increase asset size limit for webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
   mode: isProd ? 'production' : 'development',
   performance: {
     maxEntrypointSize: 768000,
-    maxAssetSize: 768000
+    maxAssetSize: 768000,
   },
   entry: {
     index: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,10 @@ const bootstrapPath = resolveModulePath('bootstrap');
 
 module.exports = {
   mode: isProd ? 'production' : 'development',
+  performance: {
+    maxEntrypointSize: 768000,
+    maxAssetSize: 768000
+  },
   entry: {
     index: {
       import: './lib/scripts/index.js',


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/905)
- - -
<!-- Reviewable:end -->
This helps to resolve issue with node 14 perfomance hints outdated

https://github.com/mongo-express/mongo-express/runs/8041715957?check_suite_focus=true