### PR TITLE
Add persist Edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
     `ME_CONFIG_OPTIONS_EDITORTHEME`   | `rubyblue`      | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
     `ME_CONFIG_OPTIONS_READONLY`      | `false`         | if readOnly is true, components of writing are not visible.
-    `ME_CONFIG_OPTIONS_NO_DELETE`      | `false`         | if noDelete is true, components of deleting are not visible.
+    `ME_CONFIG_OPTIONS_PERSIST_EDIT_MODE`   | `false`   | if set to true, remain on same page after clicked on Save button
+    `ME_CONFIG_OPTIONS_NO_DELETE`      | `false`        | if noDelete is true, components of deleting are not visible.
     `ME_CONFIG_SITE_SSL_ENABLED`      | `false`         | Enable SSL.
     `ME_CONFIG_MONGODB_SSLVALIDATE`   | `true`          | Validate mongod server certificate against CA
     `ME_CONFIG_SITE_SSL_CRT_PATH`     | ` `             | SSL certificate file.

--- a/config.default.js
+++ b/config.default.js
@@ -168,6 +168,9 @@ module.exports = {
     // readOnly: if readOnly is true, components of writing are not visible.
     readOnly: getBoolean(process.env.ME_CONFIG_OPTIONS_READONLY, false),
 
+    // persistEditMode: if set to true, remain on same page after clicked on Save button
+    persistEditMode: getBoolean(process.env.ME_CONFIG_OPTIONS_PERSIST_EDIT_MODE, false),
+
     // collapsibleJSON: if set to true, jsons will be displayed collapsible
     collapsibleJSON: true,
 

--- a/lib/routes/document.js
+++ b/lib/routes/document.js
@@ -2,7 +2,7 @@
 
 const bson = require('../bson');
 const filters = require('../filters');
-const { buildCollectionURL } = require('../utils');
+const { buildCollectionURL, buildDocumentURL } = require('../utils');
 
 const routes = function (config) {
   const exp = {};
@@ -85,7 +85,11 @@ const routes = function (config) {
 
     await req.collection.updateOne(req.document, { $set: docBSON }).then(() => {
       req.session.success = 'Document updated!';
-      res.redirect(buildCollectionURL(res.locals.baseHref, req.dbName, req.collectionName));
+      if (config.options.persistEditMode === true) {
+        res.redirect(buildDocumentURL(res.locals.baseHref, req.dbName, req.collectionName, req.document._id));
+      } else {
+        res.redirect(buildCollectionURL(res.locals.baseHref, req.dbName, req.collectionName));
+      }
     }).catch((err) => {
       // document was not saved
       req.session.error = 'Something went wrong: ' + err;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,6 +103,10 @@ exports.buildCollectionURL = function (base, dbName, collectionName) {
   return exports.buildDatabaseURL(base, dbName) + '/' + encodeURIComponent(collectionName);
 };
 
+exports.buildDocumentURL = function (base, dbName, collectionName, documentId) {
+  return exports.buildCollectionURL(base, dbName, collectionName) + '/' + encodeURIComponent(JSON.stringify(documentId));
+};
+
 exports.isValidDatabaseName = function (name) {
   if (!name || name.length > 63) {
     return false;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/910)
- - -
<!-- Reviewable:end -->
Replace PR #294

Notes:
- to URI encode the ObjectId of document, used _encodeURIComponent_ only once instead of [twice](https://github.com/mongo-express/mongo-express/pull/294/files#diff-58eee42fe4294d8ae01e252ed8cafe892fba3d803c5df5ec36b6da88e51f5946)
- URL rewrite on click of Back button not added ([commit changes](https://github.com/mongo-express/mongo-express/pull/294/files#diff-4add31d4ac6a8f0dc2a8ebc572a2ee08e9c28e58025d03a4c19d41f1d9531d0c)). Reasons:
  - needed a global context to use template engine (example {{ baseHref }}). Originally file was _document.html_ and now is _document.js_
  - this change is not really related to Edit mode feature