### PR TITLE
feature: use node 18 in github workflow and v3 workflow

### DIFF
--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [14, 16]
+        node: [14, 16, 18]
         os: [ubuntu-latest]
     name: Node v${{ matrix.node }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -27,9 +27,9 @@ jobs:
         - 27017:27017
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/912)
- - -
<!-- Reviewable:end -->
As said in https://github.com/mongo-express/mongo-express/pull/909#issuecomment-1232276388 and it is merged, this is the next step for enable node 18 in github workflow and with v3 of github actions and checkout