### PR TITLE
Remove assign of req.query

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -116,8 +116,6 @@ const routes = function (config) {
 
   // view all entries in a collection
   exp.viewCollection = async function (req, res) {
-    req.query = req.query || {}; // might not be present in Express5
-
     let query;
     let queryOptions;
     try {


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/925)
- - -
<!-- Reviewable:end -->
Replace PR #490

Express v4 and v5 have same behavior of _query_ parameters object (when no query parameter, it's always an empty Object and not undefined).

This PR only fixes the redundant assign of _query_ parameters object due to an Express v5 _change_ ([comment](https://github.com/mongo-express/mongo-express/pull/490#issuecomment-1233448564)):

```console
req.query
The req.query property is no longer a writable property and is instead a getter. The default query parser has been changed from “extended” to “simple”.
```

Tested with `4.18.1` and `5.0.0-beta.1` versions of _express_.