### PR TITLE
Simplify/improve queries logic

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -26,13 +26,12 @@ const routes = function (config) {
    * Simple/Advanced parameters input.
    * Returns null if no query parameters were passed in request.
    */
-  exp._buildMongoQuery = function (req, res, queryOptions) {
+  exp._getQuery = function (req, res, queryOptions) {
     let result = null;
     const { key } = req.query;
     let { value } = req.query;
     const type = req.query.type && req.query.type.toUpperCase();
     const jsonQuery = req.query.query;
-    const runAggregate = req.query.runAggregate === 'on';
 
     if (key && value) {
       // if it is a simple query,
@@ -74,24 +73,33 @@ const routes = function (config) {
       if (result === null) {
         throw new Error('Query entered is not valid');
       }
-      if (runAggregate) {
-        // if it's an aggregate query, add $project for projection and $facet for pagination
-        result = [
-          ...result,
-          ...(queryOptions.projection && Object.keys(queryOptions.projection).length ? [{
-            $project: queryOptions.projection,
-          }] : []),
-          {
-            $facet: {
-              metadata: [{ $count: 'total' }],
-              data: [{ $skip: queryOptions.skip }, { $limit: queryOptions.limit }],
-            },
-          },
-        ];
-      }
     }
-    // otherwise leave as null;
-    return result;
+    return [
+      {
+        $facet: {
+          data: [
+            // Array.isArray(query) checks if query is [] and exclude null/{} (bad/empty query)
+            ...req.query.runAggregate === 'on' && Array.isArray(result)
+              ? result
+              : result === null
+                ? []
+                : [{ $match: result }],
+            ...(Object.keys(queryOptions.sort).length > 0) ? [{
+              $sort: queryOptions.sort,
+            }] : [],
+            ...(Object.keys(queryOptions.projection).length > 0) ? [{
+              $project: queryOptions.projection,
+            }] : [],
+          ],
+        },
+      },
+      {
+        $project: {
+          'metadata.total': { $size: '$data' },
+          data: { $slice: ['$data', queryOptions.skip, queryOptions.limit] },
+        },
+      },
+    ];
   };
 
   exp._getSort = function (req) {
@@ -120,10 +128,6 @@ const routes = function (config) {
       projection = bson.toSafeBSON(jsonProjection) || {};
     }
     return projection;
-  };
-
-  exp._getQuery = function (req, res, queryOptions) {
-    return exp._buildMongoQuery(req, res, queryOptions) || {};
   };
 
   // view all entries in a collection
@@ -156,29 +160,20 @@ const routes = function (config) {
     };
 
     const { limit, skip, sort } = queryOptions;
-    // Array.isArray(query) checks if query is {} (bad/empty query)
-    const runAggregate = req.query.runAggregate === 'on' && Array.isArray(query);
 
     try {
-      const resultArray = await (runAggregate
-        ? req.collection.aggregate(query).toArray()
-        : req.collection.find(query, queryOptions).toArray()
-      );
-      const items = runAggregate ? resultArray && resultArray[0] && resultArray[0].data || [] : resultArray;
+      const [resultArray] = await req.collection.aggregate(query).toArray();
+      const {
+        data: items,
+        metadata: { total: count },
+      } = resultArray;
       const stats = await req.collection.stats();
       if (stats === undefined) {
         req.session.error = 'Collection not found!';
         return res.redirect('back');
       }
       const indexes = await req.collection.indexes();
-      const count = runAggregate
-        ? resultArray
-          && resultArray[0]
-          && resultArray[0].metadata
-          && resultArray[0].metadata[0]
-          && resultArray[0].metadata[0].total
-          || 0
-        : await req.collection.countDocuments(query);
+
       // Pagination
       // Have to do this here, swig template doesn't allow any calculations :(
       const prev = {


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/951)
- - -
<!-- Reviewable:end -->
Simplify/improve run aggregate feature #859.

Changes:
- Replace _find_ with _aggregate_ to:
  - Centralize query logic once
  - Remove double query to get total of documents (_countDocuments(query)_)
- Covert metadata from [{ total: \<n> }] to { total: \<n> } in result of _aggregate_
- Add missing projection filter in _aggregation_ query
- Move all filters under _$facet_ and, by this way, I think it's better to use:
  - _$size_ instead of _$count_
  - _$slice_ instead of _$size_ and $limit