### PR TITLE
Fix runAggregate state

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -274,7 +274,7 @@ const routes = function (config) {
         type: req.query.type,
         query: req.query.query,
         projection: req.query.projection,
-        runAggregate,
+        runAggregate: req.query.runAggregate === 'on',
         defaultKey,
         edKey,
         indexes,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/958)
- - -
<!-- Reviewable:end -->
Fix runAggregate state in UI with query parameter runAggregate and empty/invalid query (introduced with #946)