### PR TITLE
Disable the default basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can use the following [environment variables](https://docs.docker.com/refere
     `ME_CONFIG_HEALTH_CHECK_PATH`     | `/status`       | Set the mongo express healthcheck path. Remember to add the forward slash at the start.
     `ME_CONFIG_SITE_COOKIESECRET`     | `cookiesecret`  | String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.
     `ME_CONFIG_SITE_SESSIONSECRET`    | `sessionsecret` | String used to sign the session ID cookie by [express-session middleware](https://www.npmjs.com/package/express-session).
+    `ME_CONFIG_BASICAUTH`             | `false`         | Enable Basic Authentication. Send strings: `"true"` or `"false"`.
     `ME_CONFIG_BASICAUTH_USERNAME`    | ``              | mongo-express web login name. Sending an empty string will disable basic authentication.
     `ME_CONFIG_BASICAUTH_PASSWORD`    | ``              | mongo-express web login password.
     `ME_CONFIG_REQUEST_SIZE`          | `100kb`         | Used to configure maximum mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).

--- a/config.default.js
+++ b/config.default.js
@@ -20,6 +20,7 @@ if (process.env.VCAP_SERVICES) {
   }
 }
 
+const basicAuth = 'ME_CONFIG_BASICAUTH';
 const basicAuthUsername = 'ME_CONFIG_BASICAUTH_USERNAME';
 const basicAuthPassword = 'ME_CONFIG_BASICAUTH_PASSWORD';
 const adminUsername = 'ME_CONFIG_MONGODB_ADMINUSERNAME';
@@ -133,8 +134,8 @@ export default {
 
   // set useBasicAuth to true if you want to authenticate mongo-express logins
   // if admin is false, the basicAuthInfo list below will be ignored
-  // this will be true unless ME_CONFIG_BASICAUTH_USERNAME is set and is the empty string
-  useBasicAuth: getFileEnv(basicAuthUsername) !== '',
+  // this will be false unless ME_CONFIG_BASICAUTH is set to the true
+  useBasicAuth: getBoolean(getFileEnv(basicAuth)),
 
   basicAuth: {
     username: getFileEnv(basicAuthUsername) || 'admin',


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/975)
- - -
<!-- Reviewable:end -->
The basic authentication has been disabled by default in order to the issue mongo-express/mongo-express-docker#82

Fix #969