### PR TITLE
Remove y18n from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,3 @@ updates:
     interval: daily
   versioning-strategy: increase # Update package.json too
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-    - 4.0.2


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/982)
- - -
<!-- Reviewable:end -->
Current version of `y18n` is _5.0.8_, so remove ignore versions _4.0.1_ and _4.0.2_ from _dependabot_.