### PR TITLE
skip installation of dev packages for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk -U add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
         tini \
-    && yarn install
+    && yarn workspaces focus --production
     # && yarn run build     # prepublish already run build
 
 EXPOSE 8081


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1047)
- - -
<!-- Reviewable:end -->
Security scanner (trivy) has findings in dev packages, so excluding them from production docker image