### PR TITLE
add build stage to build with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,38 @@
+FROM node:18-alpine3.16 AS build
+
+WORKDIR /dockerbuild
+COPY . .
+
+RUN yarn install \
+    && yarn build \
+    && rm -rf /dockerbuild/lib/scripts
+
 FROM node:18-alpine3.16
 
 # "localhost" doesn't mean much in a container, so we adjust our default to the common service name "mongo" instead
 # (and make sure the server listens outside the container, since "localhost" inside the container is usually difficult to access)
-ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
-    ME_CONFIG_MONGODB_ENABLE_ADMIN="true" \
-    VCAP_APP_HOST="0.0.0.0"
+ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017"
+ENV ME_CONFIG_MONGODB_ENABLE_ADMIN="true"
+ENV VCAP_APP_HOST="0.0.0.0"
 
 WORKDIR /opt/mongo-express
-COPY . .
+
+COPY --from=build /dockerbuild/build /opt/mongo-express/build/
+COPY --from=build /dockerbuild/public /opt/mongo-express/public/
+COPY --from=build /dockerbuild/lib /opt/mongo-express/lib/
+COPY --from=build /dockerbuild/app.js /opt/mongo-express/
+COPY --from=build /dockerbuild/config.default.js /opt/mongo-express/
+COPY --from=build /dockerbuild/*.json /opt/mongo-express/
+COPY --from=build /dockerbuild/.yarn /opt/mongo-express/.yarn/
+COPY --from=build /dockerbuild/yarn.lock /opt/mongo-express/
+COPY --from=build /dockerbuild/.yarnrc.yml /opt/mongo-express/
+COPY --from=build /dockerbuild/.npmignore /opt/mongo-express/
 
 RUN apk -U add --no-cache \
-        bash \
-        # grab tini for signal processing and zombie killing
-        tini \
+        bash=5.1.16-r2 \
+        tini=0.19.0-r0 \
     && yarn workspaces focus --production
-    # && yarn run build     # prepublish already run build
 
 EXPOSE 8081
+
 CMD ["/sbin/tini", "--", "yarn", "start"]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1050)
- - -
<!-- Reviewable:end -->
to be discussed:
[from readme:](https://github.com/mongo-express/mongo-express#usage-docker)
`docker build -t mongo-express .`
won't work if not `yarn build` is called before and that will need the build environment locally installed

With this PR I've added an build stage and copy needed files into production image.