### PR TITLE
Use replace document on update

### DIFF
--- a/lib/routes/document.js
+++ b/lib/routes/document.js
@@ -83,7 +83,7 @@ const routes = function (config) {
 
     docBSON._id = req.document._id;
 
-    await req.collection.updateOne(req.document, { $set: docBSON }).then(() => {
+    await req.collection.replaceOne(req.document, docBSON).then(() => {
       req.session.success = 'Document updated!';
 
       if (config.options.persistEditMode === true) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1051)
- - -
<!-- Reviewable:end -->
When updating a document, all fields should be replaced.

## Example A:
- Create a document:
```js
{ _id: <ObjectId>, field1: 'a' }
```
- Update the document:
```js
{ _id: <ObjectId>, field2: 'b' }
```

### Output
Current (merge fields):
```js
{ _id: <ObjectId>, field1: 'a' , field2: 'b' }
```

Expected (replace fields):
```js
{ _id: <ObjectId>, field2: 'b' }
```

## Example B:
- Create a document:
```js
{ _id: <ObjectId>, field1: 'a', field2: 'b' }
```
- Update the document (remove field1):
```js
{ _id: <ObjectId>, field2: 'b' }
```

### Output
Current (no changes):
```js
{ _id: <ObjectId>, field1: 'a', field2: 'b' }
```

Expected (field1 removed):
```js
{ _id: <ObjectId>, field2: 'b' }
```