### PR TITLE
Replace custom pager and pagination with paginator-bottom

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -180,25 +180,6 @@ const routes = function (config) {
 
       // Pagination
       const { limit, skip, sort } = queryOptions;
-      // Have to do this here, swig template doesn't allow any calculations :(
-      const prev = {
-        page: Math.round((skip - limit) / limit) + 1,
-        skip: skip - limit,
-      };
-      const prev2 = {
-        page: Math.round((skip - limit * 2) / limit) + 1,
-        skip: skip - limit * 2,
-      };
-      const next2 = {
-        page: Math.round((skip + limit * 2) / limit) + 1,
-        skip: skip + limit * 2,
-      };
-      const next = {
-        page: Math.round((skip + limit) / limit) + 1,
-        skip: skip + limit,
-      };
-      const here = Math.round(skip / limit) + 1;
-      const last = (Math.ceil(count / limit) - 1) * limit;
       const pagination = count > limit;
 
       const docs = [];
@@ -261,12 +242,6 @@ const routes = function (config) {
         limit,
         skip,
         sort,
-        prev,
-        prev2,
-        next2,
-        next,
-        here,
-        last,
         pagination,
         key: req.query.key,
         value: req.query.value,

--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import htmlEntities from 'html-entities';
 import renderjson from 'renderjson';
 import CodeMirror from './codeMirrorLoader.js';
+import 'bootstrap-paginator';
 
 function getParameterByName(name) {
   // eslint-disable-next-line unicorn/better-regex
@@ -16,6 +17,21 @@ $(() => {
   if (document.location.href.includes('query=') && getParameterByName('query') !== '') {
     $('#tabs a[href="#advanced"]').tab('show');
   }
+  const { limit, skip, totalPages } = ME_SETTINGS;
+
+  // https://jacobmarshall-etc.github.io/bootstrap-paginator
+  const options = {
+    currentPage: Math.round(skip / limit) + 1,
+    totalPages,
+    centerCurrentPage: true,
+    onPageClicked(e, originalEvent, type, page) {
+      const searchParams = new URLSearchParams(window.location.search);
+      searchParams.set('skip', (page * limit) - limit);
+      window.location.search = searchParams.toString();
+    },
+  };
+  $('#paginator-top').bootstrapPaginator(options);
+  $('#paginator-bottom').bootstrapPaginator(options);
 });
 
 const addDoc = CodeMirror.fromTextArea(document.querySelector('#document'), {

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -227,23 +227,11 @@
   {% else %}
 
   {% if pagination %}
-    <ul class="pager span7">
-      <li class="previous{% if prev.skip < 0 %} disabled{% endif %}">
-        <a{% if prev.skip >= 0 %} href="{{ collectionUrl }}?skip=0&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"{% endif %}>&larr; First</a>
-      </li>
-
-      <li{% if prev.skip < 0 %} class="disabled"{% endif %}>
-        <a{% if prev.skip >= 0 %} href="{{ collectionUrl }}?skip={{ prev.skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"{% endif %}>&larr; Prev</a>
-      </li>
-
-      <li{% if next.skip >= stats.count %} class="disabled"{% endif %}>
-        <a{% if next.skip < stats.count %} href="{{ collectionUrl }}?skip={{ next.skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"{% endif %}>Next &rarr;</a>
-      </li>
-
-      <li class="next{% if next.skip >= stats.count %} disabled{% endif %}">
-        <a{% if next.skip < stats.count %} href="{{ collectionUrl }}?skip={{ last }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"{% endif %}>Last &rarr;</a>
-      </li>
-    </ul>
+    <nav>
+      <div class="text-center">
+        <div id="paginator-top"></div>
+      </div>
+    </nav>
   {% endif %}
 
   <div class="fadeToWhite" id="fadeToWhiteID"></div>
@@ -295,33 +283,7 @@
   {% if pagination %}
     <nav>
       <div class="text-center">
-      <ul class="pagination">
-        {%- if prev2.skip >= 0 %}
-        <li><a href="{{ collectionUrl }}?skip={{ prev2.skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}">{{ prev2.page }}</a></li>
-        {% else %}
-        <li><a>&nbsp;</a></li>
-        {%- endif %}
-
-        {%- if prev.skip >= 0 %}
-        <li><a href="{{ collectionUrl }}?skip={{ prev.skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}">{{ prev.page }}</a></li>
-        {% else %}
-        <li><a>&nbsp;</a></li>
-        {%- endif %}
-
-        <li class="active"><a href="{{ collectionUrl }}?skip={{ skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}">{{ here }}</a></li>
-
-        {%- if next.skip < stats.count %}
-        <li><a href="{{ collectionUrl }}?skip={{ next.skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}">{{ next.page }}</a></li>
-        {% else %}
-        <li><a>&nbsp;</a></li>
-        {% endif %}
-
-        {%- if next2.skip < stats.count %}
-        <li><a href="{{ collectionUrl }}?skip={{ next2.skip }}&key={{ key }}&value={{ value }}&type={{ type }}&query={{ query }}&projection={{ projection }}&runAggregate={{ runAggregate }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}">{{ next2.page }}</a></li>
-        {% else %}
-        <li><a>&nbsp;</a></li>
-        {% endif %}
-      </ul>
+        <div id="paginator-bottom"></div>
       </div>
     </nav>
   {% endif %}

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -111,7 +111,10 @@ window.ME_SETTINGS = {
   confirmDelete: '{{ !!settings.me_confirm_delete }}' === 'true',
   dbName: '{{ dbName | url_encode }}',
   collectionName: '{{ collectionName | url_encode }}',
-  bucketName: '{{ bucketName }}'
+  bucketName: '{{ bucketName }}',
+  limit: '{{ limit }}',
+  skip: '{{ skip }}',
+  totalPages: Math.round('{{ count }}' / '{{ limit }}')
 };
 </script>
 {% block scripts %}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.20.1",
+    "bootstrap-paginator": "github:rtritto/bootstrap-paginator#develop",
     "bson": "^4.7.0",
     "busboy": "^1.6.0",
     "cli-color": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bootstrap-paginator@github:rtritto/bootstrap-paginator#develop":
+  version: 1.0.2
+  resolution: "bootstrap-paginator@https://github.com/rtritto/bootstrap-paginator.git#commit=5a8f6b4f7b33119bd9262cfada058ff8394aac51"
+  checksum: 05b7e6384612a9bf54e8dfce33e24003b959d1b81463c76664d7738cd1f6e097b0b11663200100f63ee43b1ab6fc47a6e086b9f0c4b2bf804b4fd7f766ca3a97
+  languageName: node
+  linkType: hard
+
 "bootstrap@npm:^3.3.7":
   version: 3.4.1
   resolution: "bootstrap@npm:3.4.1"
@@ -7447,6 +7454,7 @@ __metadata:
     basic-auth-connect: "npm:^1.0.0"
     body-parser: "npm:^1.20.1"
     bootstrap: "npm:^3.3.7"
+    bootstrap-paginator: "github:rtritto/bootstrap-paginator#develop"
     bson: "npm:^4.7.0"
     busboy: "npm:^1.6.0"
     chai: "npm:^4.3.7"


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1053)
- - -
<!-- Reviewable:end -->
Replace custom _pager on top_ and _pagination on bottom_ with _bootstrap-paginator_ ([doc](https://jacobmarshall-etc.github.io/bootstrap-paginator)).

Also fix broken feature (last not existing page and prev/next pages when using query) and simplify code logic.

### Before (pages 5 and 6 not really exist):
![image](https://user-images.githubusercontent.com/40242971/203432582-f1593622-f1b7-400a-bbbb-64542fac5443.png)

### After:
![image](https://user-images.githubusercontent.com/40242971/203432708-9a87fda4-6a6c-46f4-9c24-ef5cb16a61cc.png)


## Details:
I customized `bootstrap-paginator` dependency:
1. forked from [lyonlai/bootstrap-paginator](https://github.com/lyonlai/bootstrap-paginator) to my [rtritto/bootstrap-paginator](https://github.com/rtritto/bootstrap-paginator) repository 
2. updated to v1.0.2 from bootstrap-paginator ([npm](https://www.npmjs.com/package/bootstrap-paginator))
3. added center current page feature (squash of issue https://github.com/lyonlai/bootstrap-paginator/pull/19)