### PR TITLE
Add Mongo Express Docker Extension under README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ This example links to a container name typical of `docker-compose`, changes the 
 
 The default port exposed from the container is 8081, so visit `http://localhost:8081` or whatever URL/port you entered into your config (if running standalone) or whatever `config.site.baseUrl` (if mounting as a middleware).
 
+### Using Docker Extensions:
+
+**Pre-requisite:**
+
+- Docker Desktop 4.15
+
+**Usage:**
+
+By using Mongo Express Docker Extension, it's easy to setup Mongo Express on Docker Desktop with [just one click](https://open.docker.com/extensions/marketplace?extensionId=ajeetraina/mongodb-express-docker-extension&tag=1.0).
+
+
 ## Usage (Bluemix)
 
 **Deploy to Bluemix**


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1080)
- - -
<!-- Reviewable:end -->
As per the [conversation](https://github.com/mongo-express/mongo-express/issues/1037), adding the new Mongo Express Docker Extension section that allows developers to deploy Mongo Express right with a single click.