### PR TITLE
Improve find and aggregate

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -41,7 +41,7 @@ const routes = function (config) {
   /*
    * Builds the Mongo query corresponding to the
    * Simple/Advanced parameters input.
-   * Returns null if no query parameters were passed in request.
+   * Returns {} if no query parameters were passed in request.
    */
   exp._getQuery = function (req) {
     const { key } = req.query;
@@ -122,32 +122,22 @@ const routes = function (config) {
     };
   };
 
-  exp._getQueryAggregate = function (req, query, queryOptions) {
+  exp._getQueryAggregate = function (query, queryOptions) {
     return [
-      {
-        $facet: {
-          data: [
-            // Array.isArray(query) checks if query is [] and exclude { ... } (bad/empty query)
-            ...(req.query.runAggregate === 'on' && Array.isArray(query))
-              ? query
-              : ((Object.keys(query).length > 0)
-                ? [{ $match: query }]
-                : []),
-            ...(Object.keys(queryOptions.sort).length > 0) ? [{
-              $sort: queryOptions.sort,
-            }] : [],
-            ...(Object.keys(queryOptions.projection).length > 0) ? [{
-              $project: queryOptions.projection,
-            }] : [],
-          ],
-        },
-      },
-      {
-        $project: {
-          'metadata.total': { $size: '$data' },
-          data: { $slice: ['$data', queryOptions.skip, queryOptions.limit] },
-        },
-      },
+      ...Array.isArray(query)
+        ? query
+        : ((Object.keys(query).length > 0)
+          ? [{ $match: query }]
+          : []),
+      ...(Object.keys(queryOptions.sort).length > 0) ? [{
+        $sort: queryOptions.sort,
+      }] : [],
+      ...(Object.keys(queryOptions.projection).length > 0) ? [{
+        $project: queryOptions.projection,
+      }] : [],
+      // https://stackoverflow.com/a/24161461/10413113
+      { $limit: queryOptions.limit + queryOptions.skip },
+      { $skip: queryOptions.skip },
     ];
   };
 
@@ -155,8 +145,7 @@ const routes = function (config) {
   exp.viewCollection = async function (req, res) {
     try {
       const queryOptions = exp._getQueryOptions(req);
-      const queryBase = exp._getQuery(req);
-      const query = exp._getQueryAggregate(req, queryBase, queryOptions);
+      const query = exp._getQuery(req);
 
       // determine default key
       const dbName = req.params.database;
@@ -165,18 +154,19 @@ const routes = function (config) {
         ? config.defaultKeyNames[dbName][collectionName]
         : '_id';
 
-      const [resultArray] = await req.collection.aggregate(query).toArray();
-      const {
-        data: items,
-        metadata: { total: count },
-      } = resultArray;
-      const stats = await req.collection.stats();
-      if (stats === undefined) {
-        req.session.error = 'Collection not found!';
-        console.error(req.session.error);
-        return res.redirect('back');
+      let items;
+      if (req.query.runAggregate === 'on') {
+        const queryAggregate = exp._getQueryAggregate(query, queryOptions);
+        items = await req.collection.aggregate(queryAggregate).toArray();
+      } else {
+        items = await req.collection.find(query, queryOptions).toArray();
       }
-      const indexes = await req.collection.indexes();
+
+      const [stats, indexes, count] = await Promise.all([
+        req.collection.stats(),
+        req.collection.indexes(),
+        req.collection.countDocuments(query),
+      ]);
 
       // Pagination
       const { limit, skip, sort } = queryOptions;

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -106,7 +106,7 @@ const routes = function (config) {
   };
 
   exp._getProjection = function (req) {
-    const jsonProjection = req.query.projection  || '';
+    const jsonProjection = req.query.projection || '';
     if (jsonProjection) {
       return bson.toSafeBSON(jsonProjection) || {};
     }
@@ -122,22 +122,39 @@ const routes = function (config) {
     };
   };
 
-  exp._getQueryAggregate = function (query, queryOptions) {
+  exp._getBaseAggregatePipeline = function (pipeline, queryOptions) {
     return [
-      ...Array.isArray(query)
-        ? query
-        : ((Object.keys(query).length > 0)
-          ? [{ $match: query }]
-          : []),
+      ...pipeline,
       ...(Object.keys(queryOptions.sort).length > 0) ? [{
         $sort: queryOptions.sort,
       }] : [],
       ...(Object.keys(queryOptions.projection).length > 0) ? [{
         $project: queryOptions.projection,
       }] : [],
+    ];
+  };
+
+  exp._getSimpleAggregatePipeline = function (query, queryOptions) {
+    const pipeline = Object.keys(query).length > 0
+      ? [{ $match: query }]
+      : [];
+    return [
+      ...exp._getBaseAggregatePipeline(pipeline, queryOptions),
       // https://stackoverflow.com/a/24161461/10413113
       { $limit: queryOptions.limit + queryOptions.skip },
       { $skip: queryOptions.skip },
+    ];
+  };
+
+  exp._getComplexAggregatePipeline = function (query, queryOptions) {
+    return [
+      { $facet: { data: exp._getBaseAggregatePipeline(query, queryOptions) } },
+      {
+        $project: {
+          'metadata.total': { $size: '$data' },
+          data: { $slice: ['$data', queryOptions.skip, queryOptions.limit] },
+        },
+      },
     ];
   };
 
@@ -155,17 +172,27 @@ const routes = function (config) {
         : '_id';
 
       let items;
+      let count;
       if (req.query.runAggregate === 'on') {
-        const queryAggregate = exp._getQueryAggregate(query, queryOptions);
-        items = await req.collection.aggregate(queryAggregate).toArray();
+        if (query.constructor.name === 'Object') {
+          const queryAggregate = exp._getSimpleAggregatePipeline(query, queryOptions);
+          items = await req.collection.aggregate(queryAggregate).toArray();
+          count = await req.collection.countDocuments(query);
+        } else {
+          // Array case
+          const queryAggregate = exp._getComplexAggregatePipeline(query, queryOptions);
+          const [resultArray] = await req.collection.aggregate(queryAggregate).toArray();
+          items = resultArray.data;
+          count = resultArray.metadata.total;
+        }
       } else {
         items = await req.collection.find(query, queryOptions).toArray();
+        count = await req.collection.countDocuments(query);
       }
 
-      const [stats, indexes, count] = await Promise.all([
+      const [stats, indexes] = await Promise.all([
         req.collection.stats(),
         req.collection.indexes(),
-        req.collection.countDocuments(query),
       ]);
 
       // Pagination


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1088)
- - -
<!-- Reviewable:end -->
## Changes
- As default, use _find_ instead of _aggregate_ (fix #1086).
- Add _countDocuments_ ( [doc](https://www.mongodb.com/docs/manual/reference/method/db.collection.countDocuments) ) to count all documents.
- Handle simple (Object query for $match) and complex pipeline (Array pipeline) when using advanced query in UI
- `$facet` is moved only to complex pipeline (Array pipeline) and not to default query (that will fix #1082).
- Add promise to get _stats_ and _indexes_ (removed useless check for no collection found)