### PR TITLE
Fix delete all documents

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -410,9 +410,9 @@ const routes = function (config) {
       req.session.error = 'Error: config.options.noDelete is set to true';
       return res.redirect('back');
     }
-    const query = exp._getQuery(req);
     try {
-      if (Object.keys(query).length > 0) {
+      if (req.query.query) {
+        const query = exp._getQuery(req);
         // we're just deleting some of the documents
         await req.collection.deleteMany(query).then((opRes) => {
           req.session.success = opRes.result.n + ' documents deleted from "' + req.collectionName + '"';


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1116)
- - -
<!-- Reviewable:end -->
"Delete all <N> documents retrieved" button should delete all documents instead of drop the collection.