### PR TITLE
fix: display `partialFilterExpression` as JSON in Indexes table

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -526,7 +526,16 @@
         </td>
         <td>
           {% for k,v in index %}
-          <div>{% if k != 'key' && k != 'v' && k != 'name' && k != 'ns' && k != 'size'%} {{ k }}: &nbsp;{{ v }} {% endif %}</div>
+            <div>
+              {% if k != 'key' && k != 'v' && k != 'name' && k != 'ns' && k != 'size' %}
+                {{ k }}:
+                {% if k == 'partialFilterExpression' %}
+                  <pre>{{ v | json | safe }}</pre>
+                {% else %}
+                  &nbsp;{{ v }}
+                {% endif %}
+              {% endif %}
+            </div>
           {% endfor %}
         </td>
       {% if !settings.read_only && !settings.no_delete %}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1169)
- - -
<!-- Reviewable:end -->
Fix #450

Displaying `partialFilterExpression` as JSON in Indexes table.

Here is a screenshot:
<img src="https://user-images.githubusercontent.com/22314707/229333422-abf38416-8ef6-43c4-b4e0-bdcb5b5ba4af.png" width="600">