### PR TITLE
fix: workaround for broken BinData serialization in mongodb-query-parser

### DIFF
--- a/.yarn/patches/mongodb-query-parser-npm-3.1.2-a9264cfd1f.patch
+++ b/.yarn/patches/mongodb-query-parser-npm-3.1.2-a9264cfd1f.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/stringify.js b/dist/stringify.js
+index 8e3062b89ce2a16c8885ef4a48705113dfc97328..faf11ce6fac1aecd5fd204b3cef472be430c8d67 100644
+--- a/dist/stringify.js
++++ b/dist/stringify.js
+@@ -60,7 +60,7 @@ const BSON_TO_JS_STRING = {
+         }
+         // The `Binary.buffer.toString` type says it doesn't accept
+         // arguments. However it does, and a test will fail without it.
+-        return `BinData(${subType.toString(16)}, '${v.toString('base64')}')`;
++        return `BinData(${subType.toString(10)}, '${v.toString('base64')}')`;
+     },
+     DBRef: function (v) {
+         if (v.db) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "memorystore": "^1.6.7",
     "method-override": "^3.0.0",
     "mongodb": "^4.13.0",
-    "mongodb-query-parser": "^3.1.2",
+    "mongodb-query-parser": "patch:mongodb-query-parser@npm%3A3.1.2#~/.yarn/patches/mongodb-query-parser-npm-3.1.2-a9264cfd1f.patch",
     "morgan": "^1.10.0",
     "nyc": "^15.1.0",
     "serve-favicon": "^2.5.0"

--- a/test/lib/bsonSpec.js
+++ b/test/lib/bsonSpec.js
@@ -77,6 +77,14 @@ describe('BSON', function () {
       expect(result).to.have.property('key').to.be.an.instanceof(bson.MaxKey);
     });
 
+    it('should convert BinData to BSON', function () {
+      const test = '{bin: BinData(80, "test")}';
+      const result = libBson.toBSON(test);
+
+      expect(result).to.have.property('bin').to.be.an.instanceof(bson.Binary);
+      expect(result.bin.sub_type).to.equal(80);
+    });
+
     // it('should convert Code to BSON', function () {
     //   const test = '{code: Code(function() { x; }), code2: Code("function() { x; }")}';
     //   const result = libBson.toBSON(test);
@@ -168,6 +176,12 @@ describe('BSON', function () {
       const test = { code: new bson.Code('function() { x; }') };
       const result = libBson.toString(test);
       expect(result).to.eql('{\n    code: Code(\'function() { x; }\')\n}');
+    });
+
+    it('should convert BinData to string', function () {
+      const test = { bin: new bson.Binary('test', 80) };
+      const result = libBson.toString(test);
+      expect(result).to.eql('{\n    bin: BinData(80, \'dGVzdA==\')\n}');
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8062,7 +8062,7 @@ __metadata:
     mocha: "npm:^10.2.0"
     mongodb: "npm:^4.13.0"
     mongodb-memory-server: "npm:^8.13.0"
-    mongodb-query-parser: "npm:^3.1.2"
+    mongodb-query-parser: "patch:mongodb-query-parser@npm%3A3.1.2#~/.yarn/patches/mongodb-query-parser-npm-3.1.2-a9264cfd1f.patch"
     morgan: "npm:^1.10.0"
     node-html-parser: "npm:^6.1.5"
     nodemon: "npm:^3.0.1"
@@ -8120,7 +8120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mongodb-query-parser@npm:^3.1.2":
+"mongodb-query-parser@npm:3.1.2":
   version: 3.1.2
   resolution: "mongodb-query-parser@npm:3.1.2"
   dependencies:
@@ -8131,6 +8131,20 @@ __metadata:
   peerDependencies:
     bson: ^5
   checksum: d7014d5f9c0fa58b7764cfb8b2a2a9a8cd3c2bb67514850d9e1a1c7a24314cba36cfa897875a0bcd77c8d12e16ddbba4a784a15613c7078b2194151e529f81d2
+  languageName: node
+  linkType: hard
+
+"mongodb-query-parser@patch:mongodb-query-parser@npm%3A3.1.2#~/.yarn/patches/mongodb-query-parser-npm-3.1.2-a9264cfd1f.patch":
+  version: 3.1.2
+  resolution: "mongodb-query-parser@patch:mongodb-query-parser@npm%3A3.1.2#~/.yarn/patches/mongodb-query-parser-npm-3.1.2-a9264cfd1f.patch::version=3.1.2&hash=df480d"
+  dependencies:
+    debug: "npm:^4.2.0"
+    ejson-shell-parser: "npm:^1.2.1"
+    javascript-stringify: "npm:^2.0.1"
+    lodash: "npm:^4.17.15"
+  peerDependencies:
+    bson: ^5
+  checksum: 354d5e293176a0468d5e4af7f9e5bf6b6e6baab4cdb8f71d034194174aeb311669d11a3f8d27027c313f7458613b720aec011be0fc1eab50bdde5e8e5a3b0231
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1254)
- - -
<!-- Reviewable:end -->
see #1249

This resolves the problem, but is only a workaround, as the actual fix must be done in the upstream mongodb-query-parser: mongodb-js/query-parser#136