### PR TITLE
feat: add env variable to control documents per page for collection view

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Name | Default | Description
 `ME_CONFIG_MONGODB_URL_FILE` | `` | File version of ME_CONFIG_MONGODB_URL
 `ME_CONFIG_BASICAUTH_USERNAME_FILE` | `` | File version of ME_CONFIG_BASICAUTH_USERNAME
 `ME_CONFIG_BASICAUTH_PASSWORD_FILE` | `` | File version of ME_CONFIG_BASICAUTH_PASSWORD
+`ME_CONFIG_DOCUMENTS_PER_PAGE` | `10` | How many documents you want to see at once in collection view
 
 **Example:**
 

--- a/config.default.js
+++ b/config.default.js
@@ -124,7 +124,7 @@ export default {
     console: true,
 
     // documentsPerPage: how many documents you want to see at once in collection view
-    documentsPerPage: 10,
+    documentsPerPage: process.env.ME_CONFIG_DOCUMENTS_PER_PAGE || 10,
 
     // editorTheme: Name of the theme you want to use for displaying documents
     // See http://codemirror.net/demo/theme.html for all examples


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1281)
- - -
<!-- Reviewable:end -->
We can utilize an environment variable to control the number of documents per page. If a mongo-express container is present, it may be convenient for facilitating easy viewing.