### PR TITLE
fix: add checks to ME_CONFIG_MONGODB_ENABLE_ADMIN env var to show/hide stats

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -169,10 +169,21 @@ const routes = function (config) {
         ]);
       }
 
-      const [stats, indexes] = await Promise.all([
-        req.collection.stats(),
-        req.collection.indexes(),
-      ]);
+      let stats;
+      let indexes;
+      if (config.mongodb.admin === true) {
+        [stats, indexes] = await Promise.all([
+          req.collection.stats(),
+          req.collection.indexes(),
+        ]);
+
+        const { indexSizes } = stats;
+        for (let n = 0, nn = indexes.length; n < nn; n++) {
+          indexes[n].size = indexSizes[indexes[n].name];
+        }
+      } else {
+        stats = false;
+      }
 
       const docs = [];
       let columns = [];
@@ -213,11 +224,6 @@ const routes = function (config) {
         docs[i] = items[i];
         columns.push(Object.keys(items[i]));
         items[i] = bson.toString(items[i]);
-      }
-
-      const { indexSizes } = stats;
-      for (let n = 0, nn = indexes.length; n < nn; n++) {
-        indexes[n].size = indexSizes[indexes[n].name];
       }
 
       // Generate an array of columns used by all documents visible on this page

--- a/lib/routes/database.js
+++ b/lib/routes/database.js
@@ -1,17 +1,14 @@
 import * as utils from '../utils.js';
 
-const routes = function () {
+const routes = function (config) {
   const exp = {};
 
   exp.viewDatabase = async function (req, res) {
     await req.updateCollections(req.dbConnection).then(async () => {
-      await req.db.stats().then((data) => {
-        const ctx = {
-          title: 'Viewing Database: ' + req.dbName,
-          databases: req.databases,
-          colls: req.collections[req.dbName],
-          grids: req.gridFSBuckets[req.dbName],
-          stats: {
+      let stats;
+      if (config.mongodb.admin === true) {
+        await req.db.stats().then((data) => {
+          stats = {
             avgObjSize: utils.bytesToSize(data.avgObjSize || 0),
             collections: data.collections,
             dataFileVersion: (data.dataFileVersion && data.dataFileVersion.major && data.dataFileVersion.minor
@@ -25,14 +22,23 @@ const routes = function () {
             numExtents: (data.numExtents ? data.numExtents.toString() : null),
             objects: data.objects,
             storageSize: utils.bytesToSize(data.storageSize),
-          },
-        };
-        res.render('database', ctx);
-      }).catch((error) => {
-        req.session.error = 'Could not get stats. ' + JSON.stringify(error);
-        console.error(error);
-        res.redirect('back');
-      });
+          };
+        }).catch((error) => {
+          req.session.error = 'Could not get stats. ' + JSON.stringify(error);
+          console.error(error);
+          return res.redirect('back');
+        });
+      } else {
+        stats = false;
+      }
+      const ctx = {
+        title: 'Viewing Database: ' + req.dbName,
+        databases: req.databases,
+        colls: req.collections[req.dbName],
+        grids: req.gridFSBuckets[req.dbName],
+        stats,
+      };
+      res.render('database', ctx);
     }).catch((error) => {
       req.session.error = 'Could not refresh collections. ' + JSON.stringify(error);
       console.error(error);

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -48,20 +48,23 @@ export default function (config) {
   exp.index = async function (req, res) {
     const ctx = {
       title: 'Mongo Express',
-      info: false,
     };
 
     if (req.adminDb === undefined) {
       return res.render('index');
     }
 
-    await req.adminDb.serverStatus().then((info) => {
-      ctx.info = info;
-      res.render('index', ctx);
-    }).catch((error) => {
-      // TODO: handle error
-      console.error(error);
-    });
+    if (config.mongodb.admin === true) {
+      await req.adminDb.serverStatus().then((info) => {
+        ctx.info = info;
+      }).catch((error) => {
+        // TODO: handle error
+        console.error(error);
+      });
+    } else {
+      ctx.info = false;
+    }
+    res.render('index', ctx);
   };
 
   return exp;

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -431,6 +431,7 @@
     {% endif %}
     {% endif %}
 
+  {% if stats != false %}
   <div class="stats col-md-12">
     <h2>Collection Stats</h2>
     <table class="table table-bordered table-striped">
@@ -552,6 +553,7 @@
     {% endfor %}
     </table>
   </div>
+  {% endif %}
 {% endblock %}
 
 

--- a/lib/views/database.html
+++ b/lib/views/database.html
@@ -165,6 +165,7 @@
  -->
 {% endif %}
 
+{% if stats != false %}
 <div class="panel panel-default stats">
   <div class="panel-heading">
     <h4 style="font-weight: bold;">Database Stats</h4>
@@ -232,6 +233,7 @@
     {% endif %}
   </table>
 </div>
+{% endif %}
 
 {% endblock %}
 

--- a/lib/views/index.html
+++ b/lib/views/index.html
@@ -100,14 +100,7 @@
 </form-->
 {% endif %}
 
-{% if info == false %}
-
-<h2>Server Status</h2>
-<p>
-  Turn on admin in config.js to view server stats!
-</p>
-
-{% else %}
+{% if info != false %}
 <div class="panel panel-default stats">
   <div class="panel-heading">
     <h4 style="font-weight: bold;">Server Status</h4>


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1313)
- - -
<!-- Reviewable:end -->
### Pages affected
- Server (home, list databases)
- Database (list collections)
- Collection (list documents)

### Notes
- Removed "Turn on admin in config.js to view server stats!" message when `ME_CONFIG_MONGODB_ENABLE_ADMIN=false` on Server (home) page.

Fix #1308