### PR TITLE
fix: remove useless skip query parameter

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -251,9 +251,9 @@
       </thead>
       {% for index, document in docs %}
         {% if document._id._bsontype == 'Binary' %}
-        <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}&skip={{skip}}')">
+        <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}')">
         {% else %}
-        <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?skip={{skip}}')">
+        <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}')">
         {% endif %}
           {% for column in columns %}
             <td><div class="tableContent">


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1320)
- - -
<!-- Reviewable:end -->
Remove useless `skip` _query parameter_ from document detail in collection page (documents list).