### PR TITLE
feat: add Long type support to _id

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -1,3 +1,5 @@
+import { BSON } from 'mongodb';
+
 import { addHyphensToUUID } from './utils.js';
 
 export const json = function (input) {
@@ -148,6 +150,10 @@ export const to_display = function (input) {
   return entifyGTLTAmp(input.toString());
 };
 
+export const longToString = function (input) {
+  return new BSON.Long(input.low, input.high, input.unsigned).toString();
+};
+
 function uuid4ToString(input) {
   const hex = input.toString('hex'); // same of input.buffer.toString('hex')
   return addHyphensToUUID(hex);
@@ -169,14 +175,15 @@ function uuid4ToString(input) {
 export const stringDocIDs = function (input) {
   if (input && typeof input === 'object') {
     switch (input._bsontype) {
+      case 'ObjectId':
+      case 'Long': {
+        return input.toString();
+      }
       case 'Binary': {
         if (input.sub_type === 4) {
           return uuid4ToString(input);
         }
         return input.toJSON();
-      }
-      case 'ObjectId': {
-        return input.toString();
       }
       default: {
         return input;

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -252,6 +252,8 @@
       {% for index, document in docs %}
         {% if document._id._bsontype == 'Binary' %}
         <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}&skip={{skip}}')">
+        {% elseif document._id._bsontype == 'Long' %}
+        <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | longToString | safe | url_encode }}?skip={{skip}}')">
         {% else %}
         <tr id="doc-{{ index }}" onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?skip={{skip}}')">
         {% endif %}

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -64,6 +64,11 @@
   id="documentEditForm"
   action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}&skip={{skip}}"
 >
+{% elseif document._id._bsontype == 'Long' %}
+<form method="POST"
+  id="documentEditForm"
+  action="{{ collectionUrl }}/{{ document._id | longToString | safe | url_encode }}?skip={{skip}}"
+>
 {% else %}
 <form method="POST"
   id="documentEditForm"
@@ -122,6 +127,8 @@
 
   {% if document._id._bsontype == 'Binary' %}
   <form method="POST" action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}">
+  {% elseif document._id._bsontype == 'Long' %}
+  <form method="POST" action="{{ collectionUrl }}/{{ document._id | longToString | safe | url_encode }}">
   {% else %}
   <form method="POST" action="{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}">
   {% endif %}

--- a/test/lib/routers/documentSpec.js
+++ b/test/lib/routers/documentSpec.js
@@ -1,4 +1,6 @@
-import { BSON, Binary, ObjectId } from 'mongodb';
+import {
+  BSON, Binary, Long, ObjectId,
+} from 'mongodb';
 import { expect } from 'chai';
 import { createServer, getDocumentUrl } from '../../testHttpUtils.js';
 import {
@@ -29,6 +31,28 @@ describe('Router document', () => {
       .then((res) => {
         expect(res.text).to.match(new RegExp(`<title>${docId} - Mongo Express</title>`));
       });
+  });
+  it('GET /db/<dbName>/<collection>/<document> (_id: Long - positive) should return html', async () => {
+    const long = '0';
+    const _id = new Long(long);
+    const doc = { _id };
+    await testCollection(db).insertOne(doc);
+    return request.get(`/db/${dbName}/${urlColName}/${long}`).query({ type: 'L' }).expect(200)
+      .then((res) => {
+        expect(res.text).to.match(new RegExp(`<title>${long} - Mongo Express</title>`));
+      })
+      .finally(() => testCollection(db).deleteOne({ _id }));
+  });
+  it('GET /db/<dbName>/<collection>/<document> (_id: Long - negative) should return html', async () => {
+    const long = '-1';
+    const _id = new Long(long);
+    const doc = { _id };
+    await testCollection(db).insertOne(doc);
+    return request.get(`/db/${dbName}/${urlColName}/${long}`).query({ type: 'L' }).expect(200)
+      .then((res) => {
+        expect(res.text).to.match(new RegExp(`<title>${long} - Mongo Express</title>`));
+      })
+      .finally(() => testCollection(db).deleteOne({ _id }));
   });
   it('GET /db/<dbName>/<collection>/<document> (_id: UUID) should return html', async () => {
     const uuid = new UUID().toString();


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1321)
- - -
<!-- Reviewable:end -->
### Use cases

- Positive Long
  - Create document:
  ```js
  {
      _id: NumberLong(379636166684872768)  // same of Long(379636166684872768)
  }
  ```

  - `/db/<DB>/<COLLECTION>/379636166684872768` (document detail)
  OR
  `/db/<DB>/<COLLECTION>?key=_id&value=379636166684872768&type=N` (search by Number)
  OR
  `/db/<DB>/<COLLECTION>?query=%7B%0D%0A_id%3A+NumberLong%28379636166684872768%29%0D%0A%7D` (advanced query as `{ _id: NumberLong(379636166684872768) }`)
  ```js
  {
      _id: NumberLong(379636166684872768)
  }
  ```
- Negative Long
  - Create document:
  ```js
  {
      _id: NumberLong(-379636166684872768)  // same of Long(-379636166684872768)
  }
  ```

  - `/db/<DB>/<COLLECTION>/-379636166684872768` (document detail)
  OR
  `/db/<DB>/<COLLECTION>?key=_id&value=-379636166684872768&type=N` (search by Number)
  OR
  `/db/<DB>/<COLLECTION>?query=%7B%0D%0A_id%3A+NumberLong%28-379636166684872768%29%0D%0A%7D` (advanced query as `{ _id: NumberLong(-379636166684872768) }`)
  ```js
  {
      _id: NumberLong(-379636166684872768)
  }
  ```

### Notes
- No `json` filter is used in URL (result is `/db/<DB>/<COLLECTION>/379636166684872768` instead of `/db/<DB>/<COLLECTION>/"379636166684872768"`)
  - We can also remove `json` filter to other _\_id types_

Fix #471