### PR TITLE
fix: restore bootstrap v3 logics

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -158,8 +158,7 @@
         <div class="modal-body" id="document-modal-body">
           <textarea id="document" name="document">{
     "_id": ObjectId()
-}
-          </textarea>
+}</textarea>
         </div>
         <div class="modal-footer">
           <button class="btn" data-dismiss="modal">Close</button>
@@ -192,8 +191,7 @@
           </p>
           <textarea id="index" name="index">{
     "key": 1
-}
-          </textarea>
+}</textarea>
         </div>
         <div class="modal-footer">
           <button class="btn" data-dismiss="modal">Close</button>

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -15,10 +15,10 @@
 
 {% block breadcrumb %}
 <li class="nav-item">
-  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+  <a class="nav-link px-1" href="{{ dbUrl }}">Database:</a>
 </li>
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+  <a class="nav-link dropdown-toggle px-1" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
     {{ dbName }}
   </a>
   <ul class="dropdown-menu">
@@ -28,10 +28,10 @@
   </ul>
 </li>
 <li class="nav-item">
-  <a class="nav-link" href="{{ collectionUrl }}">Collection:</a>
+  <a class="nav-link px-1" href="{{ collectionUrl }}">Collection:</a>
 </li>
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+  <a class="nav-link dropdown-toggle px-1" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
     {{ collectionName }}
   </a>
   <ul class="dropdown-menu">

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -14,9 +14,12 @@
 
 
 {% block breadcrumb %}
+<li class="nav-item">
+  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+</li>
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-    Database: {{ dbName }}
+    {{ dbName }}
   </a>
   <ul class="dropdown-menu">
     {% for db in databases %}
@@ -24,9 +27,12 @@
     {% endfor %}
   </ul>
 </li>
+<li class="nav-item">
+  <a class="nav-link" href="{{ collectionUrl }}">Collection:</a>
+</li>
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-    Collection: {{ collectionName }}
+    {{ collectionName }}
   </a>
   <ul class="dropdown-menu">
     {% for collection in collections %}

--- a/lib/views/database.html
+++ b/lib/views/database.html
@@ -3,9 +3,12 @@
 {% block title %}{{ dbName }}{% endblock %}
 
 {% block breadcrumb %}
+<li class="nav-item">
+  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+</li>
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-    Database: {{ dbName }}
+    {{ dbName }}
   </a>
   <ul class="dropdown-menu">
     {% for db in databases %}

--- a/lib/views/database.html
+++ b/lib/views/database.html
@@ -4,10 +4,10 @@
 
 {% block breadcrumb %}
 <li class="nav-item">
-  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+  <a class="nav-link px-1" href="{{ dbUrl }}">Database:</a>
 </li>
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+  <a class="nav-link dropdown-toggle px-1" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
     {{ dbName }}
   </a>
   <ul class="dropdown-menu">

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -24,29 +24,35 @@
 
 
 {% block breadcrumb %}
-  <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-      Database: {{ dbName }}
-    </a>
-    <ul class="dropdown-menu">
-      {% for db in databases %}
-      <a class="dropdown-item" href="{{ baseHref }}db/{{ db | url_encode }}/">{{ db }}</a>
-      {% endfor %}
-    </ul>
-  </li>
-  <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-      Collection: {{ collectionName }}
-    </a>
-    <ul class="dropdown-menu">
-      {% for collection in collections %}
-      <a class="dropdown-item" href="{{ dbUrl }}/{{ collection | url_encode }}">{{ collection }}</a>
-      {% endfor %}
-    </ul>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link disabled">Document {{ document._id|stringDocIDs }}</a>
-  </li>
+<li class="nav-item">
+  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+</li>
+<li class="nav-item dropdown">
+  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+    {{ dbName }}
+  </a>
+  <ul class="dropdown-menu">
+    {% for db in databases %}
+    <a class="dropdown-item" href="{{ baseHref }}db/{{ db | url_encode }}/">{{ db }}</a>
+    {% endfor %}
+  </ul>
+</li>
+<li class="nav-item">
+  <a class="nav-link" href="{{ collectionUrl }}">Collection:</a>
+</li>
+<li class="nav-item dropdown">
+  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+    {{ collectionName }}
+  </a>
+  <ul class="dropdown-menu">
+    {% for collection in collections %}
+    <a class="dropdown-item" href="{{ dbUrl }}/{{ collection | url_encode }}">{{ collection }}</a>
+    {% endfor %}
+  </ul>
+</li>
+<li class="nav-item">
+  <a class="nav-link disabled">Document {{ document._id|stringDocIDs }}</a>
+</li>
 {% endblock %}
 
 {% block content %}

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -25,10 +25,10 @@
 
 {% block breadcrumb %}
 <li class="nav-item">
-  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+  <a class="nav-link px-1" href="{{ dbUrl }}">Database:</a>
 </li>
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+  <a class="nav-link dropdown-toggle px-1" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
     {{ dbName }}
   </a>
   <ul class="dropdown-menu">
@@ -38,10 +38,10 @@
   </ul>
 </li>
 <li class="nav-item">
-  <a class="nav-link" href="{{ collectionUrl }}">Collection:</a>
+  <a class="nav-link px-1" href="{{ collectionUrl }}">Collection:</a>
 </li>
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+  <a class="nav-link dropdown-toggle px-1" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
     {{ collectionName }}
   </a>
   <ul class="dropdown-menu">

--- a/lib/views/gridfs.html
+++ b/lib/views/gridfs.html
@@ -5,10 +5,10 @@
 
 {% block breadcrumb %}
 <li class="nav-item">
-  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+  <a class="nav-link px-1" href="{{ dbUrl }}">Database:</a>
 </li>
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
+  <a class="nav-link dropdown-toggle px-1" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
     {{ dbName }}
   </a>
   <ul class="dropdown-menu">
@@ -18,7 +18,7 @@
   </ul>
 </li>
 <li class="nav-item">
-  <a class="nav-link" href="{{ dbUrl }}/{{ bucketName }}">Bucket:</a>
+  <a class="nav-link px-1" href="{{ dbUrl }}/{{ bucketName }}">Bucket:</a>
 </li>
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">

--- a/lib/views/gridfs.html
+++ b/lib/views/gridfs.html
@@ -4,9 +4,12 @@
 
 
 {% block breadcrumb %}
+<li class="nav-item">
+  <a class="nav-link" href="{{ dbUrl }}">Database:</a>
+</li>
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-    Database: {{ dbName }}
+    {{ dbName }}
   </a>
   <ul class="dropdown-menu">
     {% for db in databases %}
@@ -14,9 +17,12 @@
     {% endfor %}
   </ul>
 </li>
+<li class="nav-item">
+  <a class="nav-link" href="{{ dbUrl }}/{{ bucketName }}">Bucket:</a>
+</li>
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-expanded="false">
-    Bucket: {{ bucketName }}
+    {{ bucketName }}
   </a>
   <ul class="dropdown-menu">
     {% for bucket in buckets %}

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -18,7 +18,7 @@
 
 <body class="pb-3">
 
-  <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top p-0">
   <div class="{% if settings.fullwidth_layout %}container-fluid{% else %}container{% endif %}">
       <a class="navbar-brand" href="{{ baseHref }}">
         <img src="{{ baseHref }}public/img/mongo-express-logo.png" width="30" height="30" class="d-inline-block align-top" alt="" />


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1400)
- - -
<!-- Reviewable:end -->
Bootstrap was upadated from version 3 to 4 in #1394.

# Restore:

- Logics
  - [restore the splitted logic for link and dropdown](https://github.com/mongo-express/mongo-express/pull/1400/commits/e485f77676e32917ebb88cb9600d3f68ed8315ab)

- Bugs
  - [remove empty line at the end of textarea](https://github.com/mongo-express/mongo-express/pull/1400/commits/785e64f90de0385f58d8dd01d3c34ae3211037a2)

- Layout
  - [change padding](https://github.com/mongo-express/mongo-express/pull/1400/commits/6e19f6f9d83f570cfb04028a7517476052276ff2)