### PR TITLE
Bump codemirror to v6

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -40,7 +40,7 @@ rules:
     - devDependencies:
       - '**/test/**/*.js'
       - '**/scripts/*.js'
-      - '**/webpack.config.js'
+      - '**/webpack.config.mjs'
 
   lodash/callback-binding: error
   lodash/collection-method-value: error

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ Name | Default | Description
 `ME_CONFIG_BASICAUTH_USERNAME` | `` | mongo-express web login name. Sending an empty string will disable basic authentication.
 `ME_CONFIG_BASICAUTH_PASSWORD` | `` | mongo-express web login password.
 `ME_CONFIG_REQUEST_SIZE` | `100kb` | Used to configure maximum Mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
-`ME_CONFIG_OPTIONS_EDITORTHEME` | `rubyblue` | Web editor color theme, [more here](http://codemirror.net/demo/theme.html).
 `ME_CONFIG_OPTIONS_READONLY` | `false` | if readOnly is true, components of writing are not visible.
 `ME_CONFIG_OPTIONS_FULLWIDTH_LAYOUT` | `false` | If set to true an alternative page layout is used utilizing full window width.
 `ME_CONFIG_OPTIONS_PERSIST_EDIT_MODE` | `false` | If set to true, remain on the same page after clicking on the Save button
@@ -170,7 +169,6 @@ Name | Default | Description
         --name mongo-express \
         --network web_default \
         -p 8081:8081 \
-        -e ME_CONFIG_OPTIONS_EDITORTHEME="ambiance" \
         -e ME_CONFIG_BASICAUTH_USERNAME="" \
         -e ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
         mongo-express

--- a/README.md
+++ b/README.md
@@ -127,41 +127,41 @@ $ docker run -it --rm -p 8081:8081 --network some-network mongo-express
 
 You can use the following [environment variables](https://docs.docker.com/reference/run/#env-environment-variables) to modify the container's configuration:
 
-Name | Default | Description
-| - | - | - |
-`ME_CONFIG_MONGODB_URL` | `mongodb://admin:pass@localhost:27017/db?ssl=false`
-`ME_CONFIG_MONGODB_ENABLE_ADMIN` | `false` | Enable administrator access. Send strings: `"true"` or `"false"`.
-`ME_CONFIG_MONGODB_AUTH_USERNAME` | `admin` | Database username (only needed if `ENABLE_ADMIN` is `"false"`).
-`ME_CONFIG_MONGODB_AUTH_PASSWORD` | `pass` | Database password (only needed if `ENABLE_ADMIN` is `"false"`).
-`ME_CONFIG_MONGODB_ALLOW_DISK_USE` | `false` | Remove the limit of 100 MB of RAM on each aggregation pipeline stage.
-`ME_CONFIG_MONGODB_TLS` | `false` | Use TLS client certificate
-`ME_CONFIG_MONGODB_TLS_ALLOW_CERTS` | `true` | Validate mongod server certificate against CA
-`ME_CONFIG_MONGODB_TLS_CA_FILE` | `` | CA certificate File
-`ME_CONFIG_MONGODB_TLS_CERT_FILE` | `` | TLS client certificate file
-`ME_CONFIG_MONGODB_TLS_CERT_KEY_FILE` | `` | TLS client certificate key file
-`ME_CONFIG_MONGODB_TLS_CERT_KEY_FILE_PASSWORD` | `` | TLS client certificate key file password
-`ME_CONFIG_MONGODB_URL_FILE` | `` | File version of ME_CONFIG_MONGODB_URL
-`ME_CONFIG_SITE_BASEURL` | `/` | Set the express baseUrl to ease mounting at a subdirectory. Remember to include leading and trailing slash.
-`ME_CONFIG_HEALTH_CHECK_PATH` | `/status` | Set the mongo express healthcheck path. Remember to add the forward slash at the start.
-`ME_CONFIG_SITE_COOKIESECRET` | `cookiesecret` | String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.
-`ME_CONFIG_SITE_SESSIONSECRET` | `sessionsecret` | String used to sign the session ID cookie by [express-session middleware](https://www.npmjs.com/package/express-session).
-`ME_CONFIG_BASICAUTH` | `false` | Enable Basic Authentication. Send strings: `"true"` or `"false"`.
-`ME_CONFIG_BASICAUTH_USERNAME` | `` | mongo-express web login name. Sending an empty string will disable basic authentication.
-`ME_CONFIG_BASICAUTH_PASSWORD` | `` | mongo-express web login password.
-`ME_CONFIG_REQUEST_SIZE` | `100kb` | Used to configure maximum Mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser).
-`ME_CONFIG_OPTIONS_READONLY` | `false` | if readOnly is true, components of writing are not visible.
-`ME_CONFIG_OPTIONS_FULLWIDTH_LAYOUT` | `false` | If set to true an alternative page layout is used utilizing full window width.
-`ME_CONFIG_OPTIONS_PERSIST_EDIT_MODE` | `false` | If set to true, remain on the same page after clicking on the Save button
-`ME_CONFIG_OPTIONS_NO_DELETE` | `false` | If noDelete is true, components of deleting are not visible.
-`ME_CONFIG_SITE_SSL_ENABLED` | `false` | Enable SSL.
-`ME_CONFIG_SITE_SSL_CRT_PATH` | ` ` | SSL certificate file.
-`ME_CONFIG_SITE_SSL_KEY_PATH` | ` ` | SSL key file.
-`ME_CONFIG_SITE_GRIDFS_ENABLED` | `false` | Enable gridFS to manage uploaded files.
-`ME_CONFIG_BASICAUTH_USERNAME_FILE` | `` | File version of ME_CONFIG_BASICAUTH_USERNAME
-`ME_CONFIG_BASICAUTH_PASSWORD_FILE` | `` | File version of ME_CONFIG_BASICAUTH_PASSWORD
-`ME_CONFIG_DOCUMENTS_PER_PAGE` | `10` | How many documents you want to see at once in collection view
-`PORT` | `8081` | port that mongo-express will run on.
-`VCAP_APP_HOST` | `localhost` | address that mongo-express will listen on for incoming connections.
+| Name                                           | Default                                             | Description                                                                                                                                                                     |
+|------------------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ME_CONFIG_MONGODB_URL`                        | `mongodb://admin:pass@localhost:27017/db?ssl=false` |                                                                                                                                                                                 |
+| `ME_CONFIG_MONGODB_ENABLE_ADMIN`               | `false`                                             | Enable administrator access. Send strings: `"true"` or `"false"`.                                                                                                               |
+| `ME_CONFIG_MONGODB_AUTH_USERNAME`              | `admin`                                             | Database username (only needed if `ENABLE_ADMIN` is `"false"`).                                                                                                                 |
+| `ME_CONFIG_MONGODB_AUTH_PASSWORD`              | `pass`                                              | Database password (only needed if `ENABLE_ADMIN` is `"false"`).                                                                                                                 |
+| `ME_CONFIG_MONGODB_ALLOW_DISK_USE`             | `false`                                             | Remove the limit of 100 MB of RAM on each aggregation pipeline stage.                                                                                                           |
+| `ME_CONFIG_MONGODB_TLS`                        | `false`                                             | Use TLS client certificate                                                                                                                                                      |
+| `ME_CONFIG_MONGODB_TLS_ALLOW_CERTS`            | `true`                                              | Validate mongod server certificate against CA                                                                                                                                   |
+| `ME_CONFIG_MONGODB_TLS_CA_FILE`                | ``                                                  | CA certificate File                                                                                                                                                             |
+| `ME_CONFIG_MONGODB_TLS_CERT_FILE`              | ``                                                  | TLS client certificate file                                                                                                                                                     |
+| `ME_CONFIG_MONGODB_TLS_CERT_KEY_FILE`          | ``                                                  | TLS client certificate key file                                                                                                                                                 |
+| `ME_CONFIG_MONGODB_TLS_CERT_KEY_FILE_PASSWORD` | ``                                                  | TLS client certificate key file password                                                                                                                                        |
+| `ME_CONFIG_MONGODB_URL_FILE`                   | ``                                                  | File version of ME_CONFIG_MONGODB_URL                                                                                                                                           |
+| `ME_CONFIG_SITE_BASEURL`                       | `/`                                                 | Set the express baseUrl to ease mounting at a subdirectory. Remember to include leading and trailing slash.                                                                     |
+| `ME_CONFIG_HEALTH_CHECK_PATH`                  | `/status`                                           | Set the mongo express healthcheck path. Remember to add the forward slash at the start.                                                                                         |
+| `ME_CONFIG_SITE_COOKIESECRET`                  | `cookiesecret`                                      | String used by [cookie-parser middleware](https://www.npmjs.com/package/cookie-parser) to sign cookies.                                                                         |
+| `ME_CONFIG_SITE_SESSIONSECRET`                 | `sessionsecret`                                     | String used to sign the session ID cookie by [express-session middleware](https://www.npmjs.com/package/express-session).                                                       |
+| `ME_CONFIG_BASICAUTH`                          | `false`                                             | Enable Basic Authentication. Send strings: `"true"` or `"false"`.                                                                                                               |
+| `ME_CONFIG_BASICAUTH_USERNAME`                 | ``                                                  | mongo-express web login name. Sending an empty string will disable basic authentication.                                                                                        |
+| `ME_CONFIG_BASICAUTH_PASSWORD`                 | ``                                                  | mongo-express web login password.                                                                                                                                               |
+| `ME_CONFIG_REQUEST_SIZE`                       | `100kb`                                             | Used to configure maximum Mongo update payload size. CRUD operations above this size will fail due to restrictions in [body-parser](https://www.npmjs.com/package/body-parser). |
+| `ME_CONFIG_OPTIONS_READONLY`                   | `false`                                             | if readOnly is true, components of writing are not visible.                                                                                                                     |
+| `ME_CONFIG_OPTIONS_FULLWIDTH_LAYOUT`           | `false`                                             | If set to true an alternative page layout is used utilizing full window width.                                                                                                  |
+| `ME_CONFIG_OPTIONS_PERSIST_EDIT_MODE`          | `false`                                             | If set to true, remain on the same page after clicking on the Save button                                                                                                       |
+| `ME_CONFIG_OPTIONS_NO_DELETE`                  | `false`                                             | If noDelete is true, components of deleting are not visible.                                                                                                                    |
+| `ME_CONFIG_SITE_SSL_ENABLED`                   | `false`                                             | Enable SSL.                                                                                                                                                                     |
+| `ME_CONFIG_SITE_SSL_CRT_PATH`                  | ` `                                                 | SSL certificate file.                                                                                                                                                           |
+| `ME_CONFIG_SITE_SSL_KEY_PATH`                  | ` `                                                 | SSL key file.                                                                                                                                                                   |
+| `ME_CONFIG_SITE_GRIDFS_ENABLED`                | `false`                                             | Enable gridFS to manage uploaded files.                                                                                                                                         |
+| `ME_CONFIG_BASICAUTH_USERNAME_FILE`            | ``                                                  | File version of ME_CONFIG_BASICAUTH_USERNAME                                                                                                                                    |
+| `ME_CONFIG_BASICAUTH_PASSWORD_FILE`            | ``                                                  | File version of ME_CONFIG_BASICAUTH_PASSWORD                                                                                                                                    |
+| `ME_CONFIG_DOCUMENTS_PER_PAGE`                 | `10`                                                | How many documents you want to see at once in collection view                                                                                                                   |
+| `PORT`                                         | `8081`                                              | port that mongo-express will run on.                                                                                                                                            |
+| `VCAP_APP_HOST`                                | `localhost`                                         | address that mongo-express will listen on for incoming connections.                                                                                                             |
 
 **Example:**
 

--- a/config.default.js
+++ b/config.default.js
@@ -135,10 +135,6 @@ export default {
     // documentsPerPage: how many documents you want to see at once in collection view
     documentsPerPage: process.env.ME_CONFIG_DOCUMENTS_PER_PAGE || 10,
 
-    // editorTheme: Name of the theme you want to use for displaying documents
-    // See http://codemirror.net/demo/theme.html for all examples
-    editorTheme: process.env.ME_CONFIG_OPTIONS_EDITORTHEME || 'rubyblue',
-
     // Maximum size of a single property & single row
     // Reduces the risk of sending a huge amount of data when viewing collections
     maxPropSize: (100 * 1000), // default 100KB

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -241,7 +241,6 @@ const routes = function (config) {
         columns, // All used columns
         count, // total number of docs returned by the query
         stats,
-        editorTheme: config.options.editorTheme,
         limit,
         skip,
         sort,

--- a/lib/routes/document.js
+++ b/lib/routes/document.js
@@ -14,7 +14,6 @@ const routes = function (config) {
   exp.viewDocument = function (req, res) {
     const ctx = {
       title: (config.options.readOnly ? 'Viewing' : 'Editing') + ' Document: ' + filters.stringDocIDs(req.document._id),
-      editorTheme: config.options.editorTheme,
       docLength: bson.toString(req.document).split(/\r\n|\r|\n/).length,
       docString: bson.toString(req.document),
       skip: req.query.skip || 0,

--- a/lib/scripts/codeMirrorLoader.js
+++ b/lib/scripts/codeMirrorLoader.js
@@ -1,4 +1,0 @@
-import CodeMirror from 'codemirror';
-import 'codemirror/mode/javascript/javascript.js';
-
-export default CodeMirror;

--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -33,9 +33,13 @@ $(() => {
   $('#paginator-bottom').bootstrapPaginator(options);
 });
 
-const addDoc = editor(document.querySelector('#document'));
+const addDoc = editor(document.querySelector('#document'), {
+  readOnly: ME_SETTINGS.readOnly,
+});
 
-const addIndexDoc = editor(document.querySelector('#index'));
+const addIndexDoc = editor(document.querySelector('#index'), {
+  readOnly: ME_SETTINGS.readOnly,
+});
 
 window.checkValidJSON = function (csrfToken) {
   $.ajax({

--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 import htmlEntities from 'html-entities';
 import renderjson from 'renderjson';
-import CodeMirror from './codeMirrorLoader.js';
 import 'bootstrap-paginator-2';
+import editor from './editor.js';
 
 function getParameterByName(name) {
   // eslint-disable-next-line unicorn/better-regex
@@ -33,23 +33,9 @@ $(() => {
   $('#paginator-bottom').bootstrapPaginator(options);
 });
 
-const addDoc = CodeMirror.fromTextArea(document.querySelector('#document'), {
-  mode: { name: 'javascript', json: true },
-  indentUnit: 4,
-  electricChars: true,
-  matchBrackets: true,
-  lineNumbers: true,
-  theme: ME_SETTINGS.codeMirrorEditorTheme,
-});
+const addDoc = editor(document.querySelector('#document'));
 
-const addIndexDoc = CodeMirror.fromTextArea(document.querySelector('#index'), {
-  mode: { name: 'javascript', json: true },
-  indentUnit: 4,
-  electricChars: true,
-  matchBrackets: true,
-  lineNumbers: true,
-  theme: ME_SETTINGS.codeMirrorEditorTheme,
-});
+const addIndexDoc = editor(document.querySelector('#index'));
 
 window.checkValidJSON = function (csrfToken) {
   $.ajax({

--- a/lib/scripts/document.js
+++ b/lib/scripts/document.js
@@ -1,7 +1,9 @@
 import $ from 'jquery';
 import editor from './editor.js';
 
-const doc = editor(document.querySelector('#document'));
+const doc = editor(document.querySelector('#document'), {
+  readOnly: ME_SETTINGS.readOnly,
+});
 
 window.onBackClick = function () {
   // "Back" button is clicked

--- a/lib/scripts/document.js
+++ b/lib/scripts/document.js
@@ -1,19 +1,7 @@
 import $ from 'jquery';
-import CodeMirror from './codeMirrorLoader.js';
+import editor from './editor.js';
 
-const doc = CodeMirror.fromTextArea(document.querySelector('#document'), {
-  mode: {
-    name: 'javascript',
-    json: true,
-  },
-  indentUnit: 4,
-  lineNumbers: true,
-  autoClearEmptyLines: true,
-  matchBrackets: true,
-  readOnly: ME_SETTINGS.readOnly,
-  noDelete: ME_SETTINGS.noDelete,
-  theme: ME_SETTINGS.codeMirrorEditorTheme,
-});
+const doc = editor(document.querySelector('#document'));
 
 window.onBackClick = function () {
   // "Back" button is clicked

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -1,0 +1,34 @@
+import { basicSetup } from 'codemirror';
+import { EditorView, keymap, lineNumbers } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { indentUnit } from '@codemirror/language';
+import { javascript } from '@codemirror/lang-javascript';
+import { oneDark } from '@codemirror/theme-one-dark';
+
+const editor = (textarea) => {
+  const state = EditorState.create({
+    doc: textarea.value,
+    extensions: [
+      basicSetup,
+      history(),
+      lineNumbers(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      javascript(),
+      indentUnit.of(' '),
+      EditorState.readOnly.of(true),
+      oneDark,
+    ],
+  });
+  const view = new EditorView();
+  view.setState(state);
+  textarea.parentNode.insertBefore(view.dom, textarea);
+  textarea.style.display = 'none';
+  if (textarea.form) {
+    textarea.form.addEventListener('submit', () => {
+      textarea.value = view.state.doc.toString();
+    });
+  }
+  return view;
+};
+export default editor;

--- a/lib/scripts/editor.js
+++ b/lib/scripts/editor.js
@@ -6,7 +6,7 @@ import { indentUnit } from '@codemirror/language';
 import { javascript } from '@codemirror/lang-javascript';
 import { oneDark } from '@codemirror/theme-one-dark';
 
-const editor = (textarea) => {
+const editor = (textarea, options) => {
   const state = EditorState.create({
     doc: textarea.value,
     extensions: [
@@ -16,7 +16,7 @@ const editor = (textarea) => {
       keymap.of([...defaultKeymap, ...historyKeymap]),
       javascript(),
       indentUnit.of(' '),
-      EditorState.readOnly.of(true),
+      EditorState.readOnly.of(options.readOnly),
       oneDark,
     ],
   });

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -2,17 +2,6 @@
 
 {% block title %}{{ collectionName }}{% endblock %}
 
-
-{% block styles %}
-<link href="{{ baseHref }}public/css/codemirror.css" rel="stylesheet">
-
-{% if editorTheme != "default" %}
-<link href="{{ baseHref }}public/css/theme/{{ editorTheme }}.css" rel="stylesheet">
-{% endif %}
-
-{% endblock %}
-
-
 {% block breadcrumb %}
 <li class="nav-item">
   <a class="nav-link px-1" href="{{ dbUrl }}">Database:</a>

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -4,10 +4,6 @@
 
 
 {% block styles %}
-  <link href="{{ baseHref }}public/css/codemirror.css" rel="stylesheet">
-  {% if editorTheme != "default" %}
-  <link href="{{ baseHref }}public/css/theme/{{ editorTheme }}.css" rel="stylesheet">
-  {% endif %}
 
   <style type="text/css">
     .CodeMirror-scroll {

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -74,7 +74,6 @@
 window.ME_SETTINGS = {
   readOnly: '{{ !!settings.read_only }}' === 'true',
   noDelete: '{{ !!settings.no_delete }}' === 'true',
-  codeMirrorEditorTheme: '{{ editorTheme }}',
   baseHref: '{{ baseHref }}',
   collapsibleJSON: '{{ !!settings.me_collapsible_json }}' === 'true',
   collapsibleJSONDefaultUnfold: Number.parseInt('{{ settings.me_collapsible_json_default_unfold || 0}}', 10),

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
     "url": "git://github.com/mongo-express/mongo-express.git"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.3.3",
+    "@codemirror/lang-javascript": "^6.2.2",
+    "@codemirror/language": "^6.10.1",
+    "@codemirror/state": "^6.4.1",
+    "@codemirror/theme-one-dark": "^6.1.2",
+    "@codemirror/view": "^6.24.1",
     "@fastify/busboy": "^2.1.0",
     "@json2csv/plainjs": "^7.0.6",
     "basic-auth-connect": "^1.0.0",
@@ -32,6 +38,7 @@
     "bootstrap-paginator-2": "^2.0.0",
     "bson": "^6.2.0",
     "cli-color": "^2.0.3",
+    "codemirror": "^6.0.1",
     "commander": "^12.0.0",
     "cookie-parser": "1.4.6",
     "csurf": "1.11.0",
@@ -63,7 +70,6 @@
     "bootstrap": "^4.6.2",
     "chai": "^5.1.0",
     "clean-webpack-plugin": "^4.0.0",
-    "codemirror": "^6.0.1",
     "concurrently": "^8.2.2",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "bootstrap": "^4.6.2",
     "chai": "^5.1.0",
     "clean-webpack-plugin": "^4.0.0",
-    "codemirror": "^5.58.2",
+    "codemirror": "^6.0.1",
     "concurrently": "^8.2.2",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.10.0",

--- a/test/testDefaultConfig.js
+++ b/test/testDefaultConfig.js
@@ -28,8 +28,6 @@ export default () => ({
 
   options: {
     documentsPerPage: 10,
-    editorTheme: 'rubyblue',
-
     logger: { skip: () => true },
     readOnly: false,
   },

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -13,12 +13,6 @@ const isProd = !isDev;
 
 const fileSuffix = isDev ? '' : '-[chunkhash].min';
 
-function resolveModulePath(name) {
-  return path.dirname(require.resolve(`${name}/package.json`));
-}
-
-const codemirrorPath = resolveModulePath('codemirror');
-
 export default {
   mode: isProd ? 'production' : 'development',
   performance: {
@@ -50,7 +44,7 @@ export default {
     // Shared
     vendor: './lib/scripts/vendor.js',
     codemirror: {
-      import: './lib/scripts/codeMirrorLoader.js',
+      import: './lib/scripts/editor.js',
       dependOn: 'vendor',
     },
   },
@@ -93,9 +87,6 @@ export default {
       patterns: [
         { from: 'public/images/*', to: 'img/[name][ext]' },
         { from: 'public/stylesheets/*', to: 'css/[name][ext]' },
-
-        { from: path.join(codemirrorPath, '/lib/codemirror.css'), to: 'css/[name][ext]' },
-        { from: path.join(codemirrorPath, '/theme'), to: 'css/theme/[name][ext]' },
       ],
     }),
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1812,6 +1812,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/autocomplete@npm:^6.0.0":
+  version: 6.12.0
+  resolution: "@codemirror/autocomplete@npm:6.12.0"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.17.0"
+    "@lezer/common": "npm:^1.0.0"
+  peerDependencies:
+    "@codemirror/language": ^6.0.0
+    "@codemirror/state": ^6.0.0
+    "@codemirror/view": ^6.0.0
+    "@lezer/common": ^1.0.0
+  checksum: d01fa7e5b965285e7c26116c716c2f85d8fc4810f69abb9432dd97d60bf3a05cac547fe9dc6eaf8c7723a8621c017ff41a0b5df0e635c5a7cc37b041c7676ce8
+  languageName: node
+  linkType: hard
+
+"@codemirror/commands@npm:^6.0.0":
+  version: 6.3.3
+  resolution: "@codemirror/commands@npm:6.3.3"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.4.0"
+    "@codemirror/view": "npm:^6.0.0"
+    "@lezer/common": "npm:^1.1.0"
+  checksum: 4b398b102d6afcbf0e0018b426287a7458867497811c9155790a3cc679b880765cd756bdb96bf35abc28fecb85c0938e618d39469ce8bc0724d4dea5d88f6ac2
+  languageName: node
+  linkType: hard
+
+"@codemirror/language@npm:^6.0.0":
+  version: 6.10.1
+  resolution: "@codemirror/language@npm:6.10.1"
+  dependencies:
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.23.0"
+    "@lezer/common": "npm:^1.1.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+    style-mod: "npm:^4.0.0"
+  checksum: 14bd54aec51a36945e176ebf0e85377be498b69c4056bdca7e2eeedeea1bcc9d644a7c9d55b7340101d6e895bdbef8bc2f3ed17daa4e53a9d1ec13c4be72b0b7
+  languageName: node
+  linkType: hard
+
+"@codemirror/lint@npm:^6.0.0":
+  version: 6.5.0
+  resolution: "@codemirror/lint@npm:6.5.0"
+  dependencies:
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.0.0"
+    crelt: "npm:^1.0.5"
+  checksum: 6e369db9a1e36dbc6e7fcf34ff3f304e9c5cf2acb91f31f317430dc5c6574a7035e75b0f4e67383825ef1a31e3f76fbc202fe022f279f569a67cacf3fa06dda0
+  languageName: node
+  linkType: hard
+
+"@codemirror/search@npm:^6.0.0":
+  version: 6.5.6
+  resolution: "@codemirror/search@npm:6.5.6"
+  dependencies:
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.0.0"
+    crelt: "npm:^1.0.5"
+  checksum: 6668a34b4617e909617d3d831627d74b7a7985e8cd86d396bfcb3e86262f2310fc029fd6c846f1b8f1e6768e75985c9f1b0b18b31e05341f06b5b75c1ffde38d
+  languageName: node
+  linkType: hard
+
+"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.4.0":
+  version: 6.4.1
+  resolution: "@codemirror/state@npm:6.4.1"
+  checksum: a9ec56c7d7d52034ce8ebea3a9a4d216b9e972d701b32b5000e56c97790d0d46af129aeba0b80bed36648b4024b3ba3e4910cf5bfed11de4a9e89252e0707a70
+  languageName: node
+  linkType: hard
+
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0":
+  version: 6.24.1
+  resolution: "@codemirror/view@npm:6.24.1"
+  dependencies:
+    "@codemirror/state": "npm:^6.4.0"
+    style-mod: "npm:^4.1.0"
+    w3c-keyname: "npm:^2.2.4"
+  checksum: 66428da341241a865f75c88c4e2984234919ae46a76bba24822867166ba3d15a9df0235b120c491a5ffacdfed7f5d748cae083e19c48656ee9b93c40a5f3c7e1
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -2112,6 +2195,31 @@ __metadata:
     "@json2csv/formatters": "npm:^7.0.6"
     "@streamparser/json": "npm:^0.0.20"
   checksum: 261cce8eb0f0b8c91dee75ce1b70924a4c8bb7dc7068ede89811c20025b46a903b2e23054f31102543dad73e05072aa652a94f45a47f86e0879c63f557b296e4
+  languageName: node
+  linkType: hard
+
+"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.1.0":
+  version: 1.2.1
+  resolution: "@lezer/common@npm:1.2.1"
+  checksum: b362ed2e97664e4b36b3dbff49b52d1bfc5accc0152b577fefd46e585d012ff685d1fd336d75d80066e01c0505b1135d4cf69be5e330b5bfec2e2650c437bcae
+  languageName: node
+  linkType: hard
+
+"@lezer/highlight@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "@lezer/highlight@npm:1.2.0"
+  dependencies:
+    "@lezer/common": "npm:^1.0.0"
+  checksum: 14a80cbfb0cd1ce716decb4f3a045d42e7146f539cfd483b62ce46c4586a26d2f4fbdc35ace1cad81645304be4d30eafb95a2b057c34dfd471d56c7fbd82df3a
+  languageName: node
+  linkType: hard
+
+"@lezer/lr@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "@lezer/lr@npm:1.4.0"
+  dependencies:
+    "@lezer/common": "npm:^1.0.0"
+  checksum: 7391d0d08e54cd9e4f4d46e6ee6aa81fbaf079b22ed9c13d01fc9928e0ffd16d0c2d21b2cedd55675ad6c687277db28349ea8db81c9c69222cd7e7c40edd026e
   languageName: node
   linkType: hard
 
@@ -3772,10 +3880,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"codemirror@npm:^5.58.2":
-  version: 5.58.2
-  resolution: "codemirror@npm:5.58.2"
-  checksum: c8f3af92abb621d56db9410a90e5ca3666b1aefd153a3c5118fae12d5b33bf6d4603f40d05204432686509fc79d147cef0aa4b0dd4a93c27c7d0939dfa3e67be
+"codemirror@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "codemirror@npm:6.0.1"
+  dependencies:
+    "@codemirror/autocomplete": "npm:^6.0.0"
+    "@codemirror/commands": "npm:^6.0.0"
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/lint": "npm:^6.0.0"
+    "@codemirror/search": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.0.0"
+  checksum: 4f858cde1cf8ce4670de9df4a64f4990bb8abdb8e13d3e437f278c40c86d841ef505aa1e5dc798582109ceaac8577a3bb4a1f026c0e5ce730465c89652ee6036
   languageName: node
   linkType: hard
 
@@ -4088,6 +4204,13 @@ __metadata:
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: d0f7587346b44a1fe6c269267e037dd34b4787191e473c3e685f507229d88561c40eb18872fabfff02977301815d474300b7bfbd15396c13c5377393f7e87ec3
+  languageName: node
+  linkType: hard
+
+"crelt@npm:^1.0.5":
+  version: 1.0.6
+  resolution: "crelt@npm:1.0.6"
+  checksum: 5ed326ca6bd243b1dba6b943f665b21c2c04be03271824bc48f20dba324b0f8233e221f8c67312526d24af2b1243c023dc05a41bd8bd05d1a479fd2c72fb39c3
   languageName: node
   linkType: hard
 
@@ -7657,7 +7780,7 @@ __metadata:
     chai: "npm:^5.1.0"
     clean-webpack-plugin: "npm:^4.0.0"
     cli-color: "npm:^2.0.3"
-    codemirror: "npm:^5.58.2"
+    codemirror: "npm:^6.0.1"
     commander: "npm:^12.0.0"
     concurrently: "npm:^8.2.2"
     cookie-parser: "npm:1.4.6"
@@ -9989,6 +10112,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"style-mod@npm:^4.0.0, style-mod@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "style-mod@npm:4.1.0"
+  checksum: e0bf199d699f15d382c31ae7f18b1508f426b35346002dd1b9072db2cd32fdb0ba3ce7a4629e2fa867a79ffe4830ebf11cb9bce6500815f6a0534fac763e94f4
+  languageName: node
+  linkType: hard
+
 "superagent@npm:^8.1.2":
   version: 8.1.2
   resolution: "superagent@npm:8.1.2"
@@ -10667,6 +10797,13 @@ __metadata:
     core-util-is: "npm:1.0.2"
     extsprintf: "npm:^1.2.0"
   checksum: da548149dd9c130a8a2587c9ee71ea30128d1526925707e2d01ed9c5c45c9e9f86733c66a328247cdd5f7c1516fb25b0f959ba754bfbe15072aa99ff96468a29
+  languageName: node
+  linkType: hard
+
+"w3c-keyname@npm:^2.2.4":
+  version: 2.2.8
+  resolution: "w3c-keyname@npm:2.2.8"
+  checksum: 95bafa4c04fa2f685a86ca1000069c1ec43ace1f8776c10f226a73296caeddd83f893db885c2c220ebeb6c52d424e3b54d7c0c1e963bbf204038ff1a944fbb07
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1829,7 +1829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/commands@npm:^6.0.0":
+"@codemirror/commands@npm:^6.0.0, @codemirror/commands@npm:^6.3.3":
   version: 6.3.3
   resolution: "@codemirror/commands@npm:6.3.3"
   dependencies:
@@ -1841,7 +1841,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/language@npm:^6.0.0":
+"@codemirror/lang-javascript@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "@codemirror/lang-javascript@npm:6.2.2"
+  dependencies:
+    "@codemirror/autocomplete": "npm:^6.0.0"
+    "@codemirror/language": "npm:^6.6.0"
+    "@codemirror/lint": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.17.0"
+    "@lezer/common": "npm:^1.0.0"
+    "@lezer/javascript": "npm:^1.0.0"
+  checksum: eac2e57a7a595cf0c93afd4bb42034902230c73e5525554ba925bad12aa544ca58014c017466288a2b34f1684d6efa5537507ed8b57e276d02665c2821c7a9d6
+  languageName: node
+  linkType: hard
+
+"@codemirror/language@npm:^6.0.0, @codemirror/language@npm:^6.10.1, @codemirror/language@npm:^6.6.0":
   version: 6.10.1
   resolution: "@codemirror/language@npm:6.10.1"
   dependencies:
@@ -1877,14 +1892,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.4.0":
+"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.4.0, @codemirror/state@npm:^6.4.1":
   version: 6.4.1
   resolution: "@codemirror/state@npm:6.4.1"
   checksum: a9ec56c7d7d52034ce8ebea3a9a4d216b9e972d701b32b5000e56c97790d0d46af129aeba0b80bed36648b4024b3ba3e4910cf5bfed11de4a9e89252e0707a70
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0":
+"@codemirror/theme-one-dark@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "@codemirror/theme-one-dark@npm:6.1.2"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/state": "npm:^6.0.0"
+    "@codemirror/view": "npm:^6.0.0"
+    "@lezer/highlight": "npm:^1.0.0"
+  checksum: ea4517975b4004bd7d3ef7731a861b59c36d2ddc603d9c4ceca2c5b7637d62a8290f3f9e15004cd0f0e2ea1cc0f6c882a5ad2dd79862a6971b6654325914ccbc
+  languageName: node
+  linkType: hard
+
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.24.1":
   version: 6.24.1
   resolution: "@codemirror/view@npm:6.24.1"
   dependencies:
@@ -2198,14 +2225,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.1.0":
+"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.1.0, @lezer/common@npm:^1.2.0":
   version: 1.2.1
   resolution: "@lezer/common@npm:1.2.1"
   checksum: b362ed2e97664e4b36b3dbff49b52d1bfc5accc0152b577fefd46e585d012ff685d1fd336d75d80066e01c0505b1135d4cf69be5e330b5bfec2e2650c437bcae
   languageName: node
   linkType: hard
 
-"@lezer/highlight@npm:^1.0.0":
+"@lezer/highlight@npm:^1.0.0, @lezer/highlight@npm:^1.1.3":
   version: 1.2.0
   resolution: "@lezer/highlight@npm:1.2.0"
   dependencies:
@@ -2214,7 +2241,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/lr@npm:^1.0.0":
+"@lezer/javascript@npm:^1.0.0":
+  version: 1.4.13
+  resolution: "@lezer/javascript@npm:1.4.13"
+  dependencies:
+    "@lezer/common": "npm:^1.2.0"
+    "@lezer/highlight": "npm:^1.1.3"
+    "@lezer/lr": "npm:^1.3.0"
+  checksum: 2ebdfae4968e7d0ff1a6b21b13b511cfcc78ee08f548de0133d5dc6fa4e45f089ef35368ff82ab4370f22881768958e70d3d2d5c662784add0170a0fc48c9be0
+  languageName: node
+  linkType: hard
+
+"@lezer/lr@npm:^1.0.0, @lezer/lr@npm:^1.3.0":
   version: 1.4.0
   resolution: "@lezer/lr@npm:1.4.0"
   dependencies:
@@ -7767,6 +7805,12 @@ __metadata:
     "@babel/core": "npm:^7.23.9"
     "@babel/eslint-parser": "npm:^7.23.10"
     "@babel/preset-env": "npm:^7.23.9"
+    "@codemirror/commands": "npm:^6.3.3"
+    "@codemirror/lang-javascript": "npm:^6.2.2"
+    "@codemirror/language": "npm:^6.10.1"
+    "@codemirror/state": "npm:^6.4.1"
+    "@codemirror/theme-one-dark": "npm:^6.1.2"
+    "@codemirror/view": "npm:^6.24.1"
     "@cypress/code-coverage": "npm:^3.12.24"
     "@fastify/busboy": "npm:^2.1.0"
     "@json2csv/plainjs": "npm:^7.0.6"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1431)
- - -
<!-- Reviewable:end -->
Migrate codemirror implementation to work with codemirror v6, resolving https://github.com/mongo-express/mongo-express/pull/864 . Since code mirror no longer uses static files I have removed custom themes for now.

<img width="1177" alt="image" src="https://github.com/mongo-express/mongo-express/assets/40678306/19569c35-ba78-4a64-a041-bfe29ad4fa62">


Any suggestions are welcome!