### PR TITLE
add dark mode toggle

### DIFF
--- a/lib/scripts/vendor.js
+++ b/lib/scripts/vendor.js
@@ -2,3 +2,15 @@ import './jQueryLoader.js';
 // Need to import jQuery first to expose it on window
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap';
+import $ from 'jquery';
+
+$(() => {
+  document.body.dataset.bsTheme = localStorage.getItem('bsTheme');
+  document.querySelector('#darkModeIcon').addEventListener('click', function () {
+    this.classList.toggle('fa-moon');
+    this.classList.toggle('fa-sun');
+    const theme = document.body.dataset.bsTheme;
+    document.body.dataset.bsTheme = theme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('bsTheme', document.body.dataset.bsTheme);
+  });
+});

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -47,7 +47,7 @@
     <a href="#advanced" class="nav-link" data-bs-toggle="tab"><i class="fa fa-tag"></i> Advanced</a>
   </li>
 </ul>
-<div id="my-tab-content" class="tab-content bg-light p-3">
+<div id="my-tab-content" class="tab-content p-3">
   <div class="tab-pane active" id="simple">
     <form method="get" action="{{ collectionUrl }}">
       {% for column in columns %}

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -18,7 +18,7 @@
 
 <body class="pb-3">
 
-  <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top p-0">
+  <nav class="navbar navbar-expand-lg navbar sticky-top p-0">
   <div class="{% if settings.fullwidth_layout %}container-fluid{% else %}container{% endif %}">
       <a class="navbar-brand" href="{{ baseHref }}">
         <img src="{{ baseHref }}public/img/mongo-express-logo.png" width="30" height="30" class="d-inline-block align-top" alt="" />
@@ -33,6 +33,9 @@
           {% block breadcrumb %}
           {% endblock %}
         </ul>
+        <div class="dark-mode-toggle">
+          <i id="darkModeIcon" class="fa fa-moon"></i>
+        </div>
       </div>
   </div>
 </nav>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1458)
- - -
<!-- Reviewable:end -->
Bootstrap 5.3 made it easier, this PR only adds a button to switch between light and dark bootstrap variantes.

Related issue: https://github.com/mongo-express/mongo-express/issues/1147

I'm not good at UX so if you guys have any idea how to make it better, let me know :)

Screenshots:

<img width="1380" alt="image" src="https://github.com/mongo-express/mongo-express/assets/40678306/78a7a7e3-061a-4b17-bf79-92f12cce49fa">

<img width="1333" alt="image" src="https://github.com/mongo-express/mongo-express/assets/40678306/e23b2400-0a57-4036-ae39-be09fbce5110">

<img width="1356" alt="image" src="https://github.com/mongo-express/mongo-express/assets/40678306/c8ce664a-1a3f-415b-894f-f841d5852e0b">

<img width="1420" alt="image" src="https://github.com/mongo-express/mongo-express/assets/40678306/23ef99d2-9a38-44d0-8dcf-e69530d02e05">

<img width="1389" alt="image" src="https://github.com/mongo-express/mongo-express/assets/40678306/d2959e05-44cf-4f7c-bc32-930030c668e6">