### PR TITLE
Add JS alert to show import error

### DIFF
--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -299,6 +299,10 @@ $(() => {
         // eslint-disable-next-line no-alert
         alert(res);
         window.location.reload();
+      })
+      .catch(function (error) {
+        // eslint-disable-next-line no-alert
+        alert(error?.responseText);
       });
   });
 });


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1489)
- - -
<!-- Reviewable:end -->
show a js alert when backend returns an error after trying to import a collection