### PR TITLE
feat: use generic package manager

### DIFF
--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20, 22.4.1]
         os: [ubuntu-latest]
     name: Node v${{ matrix.node }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -35,27 +35,43 @@ View the album for more screenshots: (server status, database views, etc..)
 
 ## Development
 
-To test or develop with the latest version you can install using this git repository:
+To test or develop with the latest version (_master_ branch) you can install using this git repository:
 
-    npm i mongo-express@git+https://github.com/mongo-express/mongo-express.git#master
+    npm i mongo-express@github:mongo-express/mongo-express
+    OR
+    yarn add mongo-express@github:mongo-express/mongo-express
+    OR
+    pnpm add mongo-express@github:mongo-express/mongo-express
 
 Copy config.default.js to config.js and edit the default property to fit your local environment
 
 **Run the development build using:**
 
     npm run start-dev
+    OR
+    yarn start-dev
+    OR
+    pnpm run start-dev
 
-## Usage (npm / CLI)
+## Usage (npm / yarn / pnpm / CLI)
 
 _mongo-express_ requires Node.js v4 or higher.
 
 **To install:**
 
-    npm install -g mongo-express
+    npm i -g mongo-express
+    OR
+    yarn add -g mongo-express
+    OR
+    pnpm add -g mongo-express
 
 Or if you want to install a non-global copy:
 
-    npm install mongo-express
+    npm i mongo-express
+    OR
+    yarn add mongo-express
+    OR
+    pnpm add mongo-express
 
 By default `config.default.js` is used where the basic access authentication is `admin`:`pass`. This is obviously not safe, and there are warnings in the console.
 

--- a/package.json
+++ b/package.json
@@ -96,17 +96,16 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint .",
-    "start": "NODE_ENV=production yarn node app.js",
-    "start-dev": "concurrently --kill-others \"nodemon app.js --watch lib\" \"yarn build-dev\"",
+    "start": "NODE_ENV=production node app.js",
+    "start-dev": "concurrently --kill-others \"nodemon app.js --watch lib\" \"npm run build-dev\"",
     "build-dev": "webpack --watch",
     "build": "NODE_ENV=production webpack",
     "test": "yarn mocha && yarn lint",
     "cy:run": "cypress run",
     "mocha": "NODE_ENV=test mocha",
     "test-watch": "NODE_ENV=test mocha --watch --reporter spec",
-    "prepublish": "yarn build"
+    "prepublish": "npm run build"
   },
   "exports": "./middleware",
-  "browserslist": "defaults",
-  "packageManager": "yarn@4.1.1"
+  "browserslist": "defaults"
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "codemirror": "^6.0.1",
     "commander": "^12.1.0",
     "cookie-parser": "1.4.6",
+    "cross-env": "^7.0.3",
     "csurf": "1.11.0",
     "dotenv": "^16.4.5",
     "errorhandler": "1.5.1",
@@ -96,16 +97,17 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint .",
-    "start": "NODE_ENV=production node app.js",
-    "start-dev": "concurrently --kill-others \"nodemon app.js --watch lib\" \"npm run build-dev\"",
+    "start": "cross-env NODE_ENV=production node app.js",
+    "start-dev": "concurrently --kill-others \"nodemon app.js --watch lib\" \"webpack --watch\"",
     "build-dev": "webpack --watch",
-    "build": "NODE_ENV=production webpack",
-    "test": "yarn mocha && yarn lint",
+    "build": "cross-env NODE_ENV=production webpack",
+    "test": "cross-env NODE_ENV=test mocha && eslint .",
     "cy:run": "cypress run",
-    "mocha": "NODE_ENV=test mocha",
-    "test-watch": "NODE_ENV=test mocha --watch --reporter spec",
-    "prepublish": "npm run build"
+    "mocha": "cross-env NODE_ENV=test mocha",
+    "test-watch": "cross-env NODE_ENV=test mocha --watch --reporter spec",
+    "prepublish": "cross-env NODE_ENV=production webpack"
   },
   "exports": "./middleware",
-  "browserslist": "defaults"
+  "browserslist": "defaults",
+  "packageManager": "yarn@4.1.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3532,7 +3532,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: "npm:^7.0.1"
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 10/e99911f0d31c20e990fd92d6fd001f4b01668a303221227cc5cb42ed155f086351b1b3bd2699b200e527ab13011b032801f8ce638e6f09f854bdf744095e604c
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -6699,6 +6711,7 @@ __metadata:
     concurrently: "npm:^8.2.2"
     cookie-parser: "npm:1.4.6"
     copy-webpack-plugin: "npm:^12.0.2"
+    cross-env: "npm:^7.0.3"
     css-loader: "npm:^7.1.2"
     csurf: "npm:1.11.0"
     cypress: "npm:^13.13.0"


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1533)
- - -
<!-- Reviewable:end -->
~~- For better compatible with project using npm only~~
~~- Tested with node 18/20/22 (npm 10+)~~

Add support to package managers (not only `yarn` or `npm`):
- `yarn`
- `npm`
- _others_ (`pnpm` etc)

### TODO:
- [x] Update README

Fix #1543