### PR TITLE
chore: improve dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   versioning-strategy: increase # Update package.json too
-  open-pull-requests-limit: 10
   groups:
     patterns:
      update-types: 


### PR DESCRIPTION
### Changes
- set `interval` from _daily_ to _weekly_: to reduce _dependabot_ notifications in the single PR)
- removed `open-pull-requests-limit`: it's not needed because there is only a PR