### PR TITLE
deps: remove unused popper.js dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "node-html-parser": "^6.1.13",
     "nodemon": "^3.1.3",
     "nyc": "^15.1.0",
-    "popper.js": "^1.16.1",
     "pre-commit": "1.2.2",
     "renderjson": "github:rtritto/renderjson#develop",
     "style-loader": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7945,7 +7945,6 @@ __metadata:
     node-html-parser: "npm:^6.1.13"
     nodemon: "npm:^3.1.3"
     nyc: "npm:^15.1.0"
-    popper.js: "npm:^1.16.1"
     pre-commit: "npm:1.2.2"
     renderjson: "github:rtritto/renderjson#develop"
     serve-favicon: "npm:^2.5.0"
@@ -8809,13 +8808,6 @@ __metadata:
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
   checksum: 10/17877fdfdb7ddb3639ce257ad73a7c51a30a966091e40f56ea9f2f545b5727ce548d4928f8cb3ce38e7dc0c5150407d318af6a4ed0ea5265d378473b4c2c61ec
-  languageName: node
-  linkType: hard
-
-"popper.js@npm:^1.16.1":
-  version: 1.16.1
-  resolution: "popper.js@npm:1.16.1"
-  checksum: 10/71338c86faf9b66ce60c3cdd7fb2ed742944e5d2765a188f269239fee2980aa6223b77b41302d1b6eb7d724e611092f9a2576d0048ac2071b605291abc72c0cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1576)
- - -
<!-- Reviewable:end -->
`popper.js` is a dev dependency of Bootstrap v4 and in Bootstrap v5 it's replaced with `@popperjs/core`.
#1453 only added `@popperjs/core` and didn't removed `popper.js`.