### PR TITLE
Fix: wrong redirect after mongodb connection is enstablished

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -134,7 +134,7 @@ const router = async function (config) {
         config.mongodb.connectionString = connection.toString();
         try {
           mongo = await db(config);
-          return res.redirect('/');
+          return res.redirect(config.site.baseUrl);
         } catch (error) {
           console.debug(error);
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1679)
- - -
<!-- Reviewable:end -->
This pull request addresses an issue I've encountered deploying the application using the `ME_CONFIG_SITE_BASEURL` environment variable. 

If the provided connection string doesn't allow the connection, the application asks the users to provide the correct connection string parameters, after if the mongodb connection is enstablished, the page was redirecting to the website root `/` not honoring the baseUrl config variable.