### PR TITLE
Security Fix: Hide Backend-Specified Password on Login Page

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -23,6 +23,8 @@ const ALLOWED_SUBTYPES = new Set([
   mongodb.Binary.SUBTYPE_UUID,
 ]);
 
+const PASSWORD_PLACEHOLDER = '••••••••••••••••';
+
 const addTrailingSlash = function (s) {
   return s + (s.at(-1) === '/' ? '' : '/');
 };
@@ -129,8 +131,10 @@ const router = async function (config) {
         connection.hostname = hostname;
         connection.port = port;
         connection.username = username;
-        connection.password = password;
         connection.searchParams.set('authSource', authSource);
+        if (password !== PASSWORD_PLACEHOLDER) {
+          connection.password = password;
+        }
         config.mongodb.connectionString = connection.toString();
         try {
           mongo = await db(config);
@@ -144,7 +148,7 @@ const router = async function (config) {
         csrfToken: req.csrfToken(),
         authSource: connection.searchParams.get('authSource') ?? '',
         username: connection.username,
-        password: connection.password,
+        password: PASSWORD_PLACEHOLDER,
         hostname: connection.hostname,
         port: connection.port,
       });


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1681)
- - -
<!-- Reviewable:end -->
While deploying the software, I noticed that in the event of a broken connection, mongo-express exposes the password to the logged-in user, creating a security vulnerability.

This PR addresses the issue by introducing a password placeholder. The placeholder replaces the password on the login page, and the backend only interprets the new value if it differs from the placeholder.