### PR TITLE
update dockerfile to node20 for proper use of `import.meta.dirname`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.16 AS build
+FROM node:20-alpine3.21 AS build
 
 WORKDIR /dockerbuild
 COPY . .
@@ -7,7 +7,7 @@ RUN yarn install \
     && yarn build \
     && rm -rf /dockerbuild/lib/scripts
 
-FROM node:18-alpine3.16
+FROM node:20-alpine3.21
 
 # "localhost" doesn't mean much in a container, so we adjust our default to the common service name "mongo" instead
 # (and make sure the server listens outside the container, since "localhost" inside the container is usually difficult to access)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1713)
- - -
<!-- Reviewable:end -->
Hey Folks,

with [this change](https://github.com/mongo-express/mongo-express/commit/599947b341ba761738f17db84b7aef0c8b1b33db) it is required to run `mongo-express` with node `20.11`(at least) in order to properly use `import.meta.dirname`.

Therefore the `Dockerfile` should also use the proper node-version. Otherwise you'll encounter this error:

```
node:internal/errors:490
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:399:5)
    at validateString (node:internal/validators:163:11)
    at Object.join (node:path:1172:7)
    at file:///opt/mongo-express/app.js:14:45
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v18.16.0
```