### PR TITLE
feat: use generic dirname

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import https from 'node:https';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import pico from 'picocolors';
 import { program } from 'commander';
 import csrf from 'csurf';
@@ -11,7 +12,10 @@ import middleware from './lib/middleware.js';
 import { deepmerge } from './lib/utils.js';
 import configDefault from './config.default.js';
 
-const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, './package.json')));
+// TODO replace with import.meta.dirname if minimum Node.js version is >= 20.11.0
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, './package.json')));
 
 const app = express();
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1715)
- - -
<!-- Reviewable:end -->
[import.meta.dirname](https://nodejs.org/api/esm.html#importmetadirname) was introduced with Node.js version >= 20.11.0/21.2.0.
Use generic dirname compatible with ESM.