### PR TITLE
fix:add scroll to list of collections and databases from navbar 

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -7,7 +7,7 @@
   <a class="nav-link dropdown-toggle" href="#" role="button" aria-controls="navbarDatabaseDropdown" data-bs-target="#navbarDatabaseDropdown" data-bs-toggle="collapse" aria-expanded="false">
     Database: {{ dbName }}
   </a>
-  <ul id="navbarDatabaseDropdown" class="dropdown-menu">
+  <ul id="navbarDatabaseDropdown" class="dropdown-menu scrollable-ul">
     {% for db in databases %}
     <li><a class="dropdown-item" href="{{ baseHref }}db/{{ db | url_encode }}/">{{ db }}</a></li>
     {% endfor %}
@@ -17,11 +17,12 @@
   <a class="nav-link dropdown-toggle" href="#" role="button" aria-controls="navbarCollectionDropdown" data-bs-target="#navbarCollectionDropdown" data-bs-toggle="collapse" aria-expanded="false">
     Collection: {{ collectionName }}
   </a>
-  <ul id="navbarCollectionDropdown" class="dropdown-menu">
-    {% for collection in collections %}
-    <li><a class="dropdown-item" href="{{ dbUrl }}/{{ collection | url_encode }}">{{ collection }}</a></li>
-    {% endfor %}
-  </ul>
+    <ul id="navbarCollectionDropdown" class="dropdown-menu scrollable-ul">
+      {% for collection in collections %}
+      <li><a class="dropdown-item" href="{{ dbUrl }}/{{ collection | url_encode }}">{{ collection }}</a></li>
+      {% endfor %}
+    </ul>
+
 </li>
 {% endblock %}
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -52,3 +52,8 @@
   border-radius: 4px; /* future proofing */
   -khtml-border-radius: 4px; /* for old Konqueror browsers */
 }
+
+.scrollable-ul {
+  overflow-y: auto;
+  max-height: 90vh;
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1745)
- - -
<!-- Reviewable:end -->
### Description
If there are a lot of collections/databases and you want to switch using the navbar menu, the `ul` element is not scrollable.
<img width="662" alt="Screenshot 2025-04-05 alle 12 00 21" src="https://github.com/user-attachments/assets/81f13068-bf71-45b1-82f8-9b2f0fe4642b" />

This PR aims to fix this behavior by adding a css class that add the overflow style in case the number of the elements in the `ul` exceeds the maximum based on the height of the screen.
Here is the result
<img width="560" alt="Screenshot 2025-04-05 alle 12 01 37" src="https://github.com/user-attachments/assets/75834908-6586-4faf-8a14-d2c48f4598d5" />

Made during [![Open Source Saturday Italy](https://img.shields.io/badge/Open%20Source%20Saturday-Italy-red)](https://oss-italy.github.io/)