### PR TITLE
html-entities import error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "flat": "^6.0.1",
     "free-swig": "^1.5.5",
     "gridfs-stream": "^1.1.1",
-    "html-entities": "^2.5.2",
+    "html-entities": "~2.5.6",
     "jquery": "^3.7.1",
     "memorystore": "^1.6.7",
     "method-override": "^3.0.0",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1753)
- - -
<!-- Reviewable:end -->
The current main branch imports any minor version of html-entities.
They just released v2.6.0, that gets imported by npm.
However this brings some compilation error, like 

```
ERROR in ./lib/scripts/collection.js 114:24-43
export 'default' (imported as 'htmlEntities') was not found in 'html-entities' (possible exports: decode, decodeEntity, encode)

ERROR in ./lib/scripts/collection.js 119:55-74
export 'default' (imported as 'htmlEntities') was not found in 'html-entities' (possible exports: decode, decodeEntity, encode)

ERROR in ./lib/scripts/collection.js 125:44-63
export 'default' (imported as 'htmlEntities') was not found in 'html-entities' (possible exports: decode, decodeEntity, encode)

ERROR in ./lib/scripts/collection.js 125:86-105
export 'default' (imported as 'htmlEntities') was not found in 'html-entities' (possible exports: decode, decodeEntity, encode)

ERROR in ./lib/scripts/collection.js 133:9-28
export 'default' (imported as 'htmlEntities') was not found in 'html-entities' (possible exports: decode, decodeEntity, encode)

```

This patch just ensure mongo-express stays with version 2.5.x by changing in package.json to
    "html-entities": "~2.5.6",