### PR TITLE
Add FerretDB as a supported MongoDB-compatible application

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/mongo-express.svg)](https://www.npmjs.com/package/mongo-express) [![npm](https://img.shields.io/npm/dm/mongo-express.svg)](https://www.npmjs.com/package/mongo-express) [![GitHub stars](https://img.shields.io/github/stars/mongo-express/mongo-express.svg)](https://github.com/mongo-express/mongo-express/stargazers) [![Known Vulnerabilities](https://snyk.io/test/npm/name/badge.svg)](https://snyk.io/test/npm/mongo-express)
 [![Build Status](https://github.com/mongo-express/mongo-express/actions/workflows/standard-ci.yml/badge.svg?branch=master)](https://github.com/mongo-express/mongo-express/actions/workflows/standard-ci.yml)
 
-A web-based admin interface for MongoDB and FerretDB, built with Node.js, Express, and Bootstrap 5.
+A web-based admin interface for MongoDB or compatible services (FerretDB, Amazon DocumentDB). Built with Node.js, Express, and Bootstrap 5.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![npm version](https://badge.fury.io/js/mongo-express.svg)](https://www.npmjs.com/package/mongo-express) [![npm](https://img.shields.io/npm/dm/mongo-express.svg)](https://www.npmjs.com/package/mongo-express) [![GitHub stars](https://img.shields.io/github/stars/mongo-express/mongo-express.svg)](https://github.com/mongo-express/mongo-express/stargazers) [![Known Vulnerabilities](https://snyk.io/test/npm/name/badge.svg)](https://snyk.io/test/npm/mongo-express)
 [![Build Status](https://github.com/mongo-express/mongo-express/actions/workflows/standard-ci.yml/badge.svg?branch=master)](https://github.com/mongo-express/mongo-express/actions/workflows/standard-ci.yml)
 
-A web-based MongoDB admin interface written with Node.js, Express, and Bootstrap 5
+A web-based MongoDB admin interface written with Node.js, Express, and Bootstrap 5.
+Also works with FerretDB, a PostgreSQL-backed MongoDB alternative.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![npm version](https://badge.fury.io/js/mongo-express.svg)](https://www.npmjs.com/package/mongo-express) [![npm](https://img.shields.io/npm/dm/mongo-express.svg)](https://www.npmjs.com/package/mongo-express) [![GitHub stars](https://img.shields.io/github/stars/mongo-express/mongo-express.svg)](https://github.com/mongo-express/mongo-express/stargazers) [![Known Vulnerabilities](https://snyk.io/test/npm/name/badge.svg)](https://snyk.io/test/npm/mongo-express)
 [![Build Status](https://github.com/mongo-express/mongo-express/actions/workflows/standard-ci.yml/badge.svg?branch=master)](https://github.com/mongo-express/mongo-express/actions/workflows/standard-ci.yml)
 
-A web-based MongoDB admin interface written with Node.js, Express, and Bootstrap 5.
-Also works with FerretDB, a PostgreSQL-backed MongoDB alternative.
+A web-based admin interface for MongoDB and FerretDB, built with Node.js, Express, and Bootstrap 5.
 
 ## Features
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1768)
- - -
<!-- Reviewable:end -->
This PR updates the README to mention [compatibility with FerretDB](https://blog.ferretdb.io/seamlessly-manage-ferretdb-mongo-express/), an open-source MongoDB alternative that uses PostgreSQL as the backend.