### PR TITLE
fix: type confusion through parameter tampering

### DIFF
--- a/lib/routes/gridfs.js
+++ b/lib/routes/gridfs.js
@@ -10,6 +10,12 @@ const routes = function () {
   // view all files in a bucket
   exp.viewBucket = function (req, res) {
     const { bucketName, dbName, files } = req;
+
+    if (!Array.isArray(files) || files.length === 0 || typeof files[0] !== 'object') {
+      // Defensive: if not valid, don't continue. Could customize this to show an appropriate error page.
+      return res.status(400).send("Bad files parameter");
+    }
+
     let columns = ['filename', 'length']; // putting these here keeps them at the front/left
 
     const statsAvgChunk  = utils.bytesToSize(files.reduce((prev, curr) => prev + curr.chunkSize, 0) / files.length);


### PR DESCRIPTION
Sanitizing untrusted HTTP request parameters is a common technique for preventing injection attacks such as SQL injection or path traversal. This is sometimes done by checking if the request parameters contain blacklisted substrings, sanitizing request parameters assuming they have type String and using the builtin string methods such as `String.prototype.indexOf` is susceptible to type confusion attacks. In a type confusion attack, an attacker tampers with an HTTP request parameter such that it has a value of type Array instead of the expected type String. Furthermore, the content of the array has been crafted to bypass sanitizers by exploiting that some identically named methods of strings and arrays behave differently.

https://github.com/mongo-express/mongo-express/blob/96ab411e82ec7d43f09bb3d14fe4ccd4b5bc1f51/lib/routes/gridfs.js#L12-L15

To prevent type confusion attacks, we must ensure that `files` is in fact an array of objects with the expected structure before performing array operations like `reduce`, `.length`, or `for-in` loops. The best way is to check at runtime whether `files` is an array (using `Array.isArray(files)`), and that it contains at least one element, and optionally that its elements have the expected properties (like `.chunkSize` and `.length`). If these conditions do not hold, return an error or display an empty result, depending on semantics.

**What to change:**
- In `exp.viewBucket`, add a runtime type check at the top of the function to ensure `files` is an array and is nonempty before proceeding with array operations. If not, respond with an error or handle as appropriate.
- This all happens in `lib/routes/gridfs.js`, lines 11–43 (the `viewBucket` function).

### References
[Node.js API querystring](https://nodejs.org/api/querystring.html)