### PR TITLE
fix: code scanning alert no. 24: Type confusion through parameter tampering

### DIFF
--- a/lib/routes/gridfs.js
+++ b/lib/routes/gridfs.js
@@ -10,8 +10,8 @@ const routes = function () {
   // view all files in a bucket
   exp.viewBucket = function (req, res) {
     const { bucketName, dbName, files } = req;
-    if (!Array.isArray(files)) {
-      return res.status(400).send('Invalid files parameter.');
+    if (!Array.isArray(files) || files.length === 0) {
+      return res.status(400).send('Invalid or empty files parameter.');
     }
     let columns = ['filename', 'length']; // putting these here keeps them at the front/left
 

--- a/lib/routes/gridfs.js
+++ b/lib/routes/gridfs.js
@@ -10,12 +10,14 @@ const routes = function () {
   // view all files in a bucket
   exp.viewBucket = function (req, res) {
     const { bucketName, dbName, files } = req;
-    if (!Array.isArray(files) || files.length === 0) {
-      return res.status(400).send('Invalid or empty files parameter.');
+    if (!Array.isArray(files)) {
+      return res.status(400).send('Invalid files parameter.');
     }
     let columns = ['filename', 'length']; // putting these here keeps them at the front/left
 
-    const statsAvgChunk  = utils.bytesToSize(files.reduce((prev, curr) => prev + curr.chunkSize, 0) / files.length);
+    const statsAvgChunk  = files.length === 0
+      ? utils.bytesToSize(0)
+      : utils.bytesToSize(files.reduce((prev, curr) => prev + curr.chunkSize, 0) / files.length);
     const statsTotalSize = utils.bytesToSize(files.reduce((prev, curr) => prev + curr.length, 0));
 
     // Iterate through files for a cleanup

--- a/lib/routes/gridfs.js
+++ b/lib/routes/gridfs.js
@@ -10,6 +10,9 @@ const routes = function () {
   // view all files in a bucket
   exp.viewBucket = function (req, res) {
     const { bucketName, dbName, files } = req;
+    if (!Array.isArray(files)) {
+      return res.status(400).send('Invalid files parameter.');
+    }
     let columns = ['filename', 'length']; // putting these here keeps them at the front/left
 
     const statsAvgChunk  = utils.bytesToSize(files.reduce((prev, curr) => prev + curr.chunkSize, 0) / files.length);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1801)
- - -
<!-- Reviewable:end -->
Potential fix for [https://github.com/mongo-express/mongo-express/security/code-scanning/24](https://github.com/mongo-express/mongo-express/security/code-scanning/24)

To fix the vulnerability, the code should verify at runtime that `files` is indeed an array before performing operations that assume array semantics (such as reduce and for-in iteration). If `files` is not an array, the request should be rejected gracefully, as this indicates potential tampering or an unexpected shape of input data.

Specifically:
- In `exp.viewBucket`, right after destructuring `files` from `req`, check that `files` is an array (`Array.isArray(files)`).
- If the check fails, send a 400 response indicating invalid parameters.

Only add code within the provided snippet for the handler function in `lib/routes/gridfs.js`. No external dependencies are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._