### PR TITLE
fix: restore collection sorting broken by Express 5 default query parser

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -34,6 +34,9 @@ const parseRequestSizeLimit = (limit) => {
 const middleware = async function (config) {
   const app = express();
 
+  // Express 5 defaults to 'simple' query parser which ignores nested keys like sort[name]=1
+  app.set('query parser', 'extended');
+
   app.locals.assets = JSON.parse(fs.readFileSync(fileURLToPath(new URL('../build-assets.json', import.meta.url))));
 
   // Set up swig


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1874)
- - -
<!-- Reviewable:end -->
## Problem

Since the Express 5 upgrade (#1630), sorting collection documents by clicking a column header no longer works: the URL contains the expected `sort[column]=1` parameter and the sort icon is rendered, but documents come back in their natural order.

## Root cause

Express 5 changed the default query parser from `extended` to `simple` (see https://expressjs.com/en/guide/migrating-5.html#req.query). With the `simple` parser, bracket notation is no longer decoded into nested objects:

```
?sort[name]=1
```

now produces `req.query = { 'sort[name]': '1' }` instead of `req.query = { sort: { name: '1' } }`.

`_getSort()` in `lib/routes/collection.js` reads `req.query.sort`, which is now always `undefined`, so an empty sort is silently passed to MongoDB. The same applies to every nested query parameter read by the app.

## Fix

Restore the Express 4 behavior by explicitly selecting the `extended` query parser on the middleware app:

```js
app.set('query parser', 'extended');
```

## How to verify

1. Open any collection with more than one document
2. Click a column header to sort it
3. Before this fix: the sort icon and URL update, but the document order does not change
4. With this fix: documents are sorted ascending/descending/unsorted as you cycle through clicks