### PR TITLE
feat: ctrl/cmd+click on a document row opens it in a new tab

### DIFF
--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -109,10 +109,21 @@ function makeCollectionUrl() {
   return `${st.baseHref}db/${encodeURIComponent(st.dbName)}/${encodeURIComponent(st.collectionName)}/`;
 }
 
-globalThis.loadDocument = function (url) {
+globalThis.loadDocument = function (url, event) {
   const selection = globalThis.getSelection().toString();
-  if (selection === '') {
-    globalThis.location.href = url;
+  if (selection !== '') {
+    return;
+  }
+  // document URLs are always relative to the app; refuse anything that
+  // would resolve to another origin
+  const target = new URL(url, globalThis.location.href);
+  if (target.origin !== globalThis.location.origin) {
+    return;
+  }
+  if (event && (event.ctrlKey || event.metaKey)) {
+    globalThis.open(target.href, '_blank');
+  } else {
+    globalThis.location.href = target.href;
   }
 };
 

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -224,13 +224,13 @@
     {% for index, document in docs %}
     {% if document._id._bsontype == 'Binary' %}
     <tr id="doc-{{ index }}"
-      onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}&skip={{skip}}')">
+      onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?subtype={{ document._id.sub_type }}&skip={{skip}}', event)">
       {% elseif document._id._bsontype == 'Long' %}
     <tr id="doc-{{ index }}"
-      onclick="loadDocument('{{ collectionUrl }}/{{ document._id | longToString | safe | url_encode }}?skip={{skip}}')">
+      onclick="loadDocument('{{ collectionUrl }}/{{ document._id | longToString | safe | url_encode }}?skip={{skip}}', event)">
       {% else %}
     <tr id="doc-{{ index }}"
-      onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?skip={{skip}}')">
+      onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}?skip={{skip}}', event)">
       {% endif %}
       {% for column in columns %}
       <td>
@@ -238,7 +238,7 @@
           {% if !settings.read_only && !settings.no_delete && column === '_id' && collectionName !== 'system.indexes'
           %}
           <button class="btn btn-info"
-            onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}')">
+            onclick="loadDocument('{{ collectionUrl }}/{{ document._id | json | safe | url_encode }}', event)">
             <i class="fa fa-link"></i>
           </button>
           <form class="deleteButtonDocument" method="POST" style="display:inline;"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1875)
- - -
<!-- Reviewable:end -->
## Problem

In the collection view, document rows are `<tr>` elements with an `onclick` handler that always navigates in the current tab. Ctrl+click (or Cmd+click on macOS) — the universal "open in a new tab" gesture — is silently ignored, because rows are not real links and the handler unconditionally sets `location.href`.

When browsing documents (e.g. comparing several of them, or keeping the collection list open), this forces a constant back-and-forth navigation.

## Solution

Pass the click event to `loadDocument()` and honor the modifier keys:

- **Ctrl/Cmd + click** on a document row (or on the `_id` link button) opens the document in a new tab via `window.open(url, '_blank')`
- **plain click** keeps the current behavior (`location.href`)
- the existing guard that ignores clicks when text is selected is preserved

## Notes

Middle-click is not covered: browsers do not fire `click` on `<tr>` elements for the middle button, that would require turning rows into real anchors — a much more invasive change.

## How to verify

1. Open any collection with documents
2. Ctrl+click (Cmd+click on macOS) a row → the document opens in a new tab, current page stays
3. Plain click a row → navigates in the current tab, as before
4. Select some text in a cell and click → no navigation, as before