### PR TITLE
feat: drag-and-drop column reordering and always-visible sort icons

### DIFF
--- a/lib/scripts/collection.js
+++ b/lib/scripts/collection.js
@@ -266,6 +266,70 @@ $(() => {
     $('#my-tab-content .tab-pane.active form').trigger('submit');
   });
 
+  // Column reordering via drag-and-drop, order persisted per collection in localStorage
+  const $table = $('.tableHeaderFooterBars');
+  if ($table.length > 0) {
+    const storageKey = `mongo-express:columnOrder:${ME_SETTINGS.dbName}/${ME_SETTINGS.collectionName}`;
+
+    const headers = () => $table.find('thead th').toArray();
+    const currentOrder = () => headers().map((th) => $(th).attr('data-column'));
+
+    const applyOrder = (order) => {
+      const cols = currentOrder();
+      const indexMap = order.map((c) => cols.indexOf(c)).filter((i) => i !== -1);
+      $table.find('tr').each(function () {
+        const cells = $(this).children('th, td').toArray();
+        if (cells.length !== cols.length) return;
+        for (const i of indexMap) $(this).append(cells[i]);
+      });
+    };
+
+    const saved = JSON.parse(localStorage.getItem(storageKey) || 'null');
+    if (Array.isArray(saved)) {
+      const cols = currentOrder();
+      applyOrder([...saved.filter((c) => cols.includes(c)), ...cols.filter((c) => !saved.includes(c))]);
+    }
+
+    // drag only starts from the handle — keeping the rest of the th as a plain sort button
+    // (a fully draggable th eats click events on any slight mouse movement)
+    $table.find('thead th').prepend('<i class="fas fa-arrows-alt-h column-drag-handle" draggable="true" title="Drag to reorder column"></i>');
+
+    let dragFrom = null;
+    $table
+      .on('click', '.column-drag-handle', (e) => e.stopPropagation())
+      .on('dragstart', '.column-drag-handle', function (e) {
+        dragFrom = headers().indexOf($(this).closest('th')[0]);
+        e.originalEvent.dataTransfer.effectAllowed = 'move';
+        e.originalEvent.dataTransfer.setData('text/plain', ''); // required by Firefox
+      })
+      .on('dragend', '.column-drag-handle', function () {
+        $table.find('.column-drop-target').removeClass('column-drop-target');
+        dragFrom = null;
+      });
+
+    $table.find('thead th')
+      .on('dragover', function (e) {
+        if (dragFrom === null) return;
+        e.preventDefault();
+        e.originalEvent.dataTransfer.dropEffect = 'move';
+        $(this).addClass('column-drop-target');
+      })
+      .on('dragleave', function () {
+        $(this).removeClass('column-drop-target');
+      })
+      .on('drop', function (e) {
+        e.preventDefault();
+        $(this).removeClass('column-drop-target');
+        const to = headers().indexOf(this);
+        if (dragFrom === null || to === dragFrom) return;
+        const order = currentOrder();
+        order.splice(to, 0, order.splice(dragFrom, 1)[0]);
+        applyOrder(order);
+        localStorage.setItem(storageKey, JSON.stringify(order));
+        dragFrom = null;
+      });
+  }
+
   const $importInputsFile = $('.import-input-file');
   const $importFileLinks = $('.import-file-link');
 

--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -214,9 +214,11 @@
       <th class="sorting-button" data-column="{{column}}" data-direction="{{sort[column]}}" title="Sort by {{column}}">
         {{column}}
         {% if sort[column] == 1 %}
-        <i class="fas fa-sort-up"></i>
+        <i class="fas fa-sort-up sort-icon active"></i>
         {% elseif sort[column] == -1 %}
-        <i class="fas fa-sort-down"></i>
+        <i class="fas fa-sort-down sort-icon active"></i>
+        {% else %}
+        <i class="fas fa-sort sort-icon"></i>
         {% endif %}
       </th>
       {% endfor %}

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -12,6 +12,44 @@
   border-bottom-style: solid;
 }
 
+.tableHeaderFooterBars thead th {
+  white-space: nowrap;
+  user-select: none;
+  vertical-align: middle;
+}
+
+.tableHeaderFooterBars thead th .sort-icon {
+  opacity: 0.25;
+  font-size: 0.8em;
+  margin-left: 2px;
+}
+
+.tableHeaderFooterBars thead th .sort-icon.active {
+  opacity: 1;
+  color: #337ab7;
+}
+
+.column-drop-target {
+  outline: 2px dashed #0d6efd;
+  outline-offset: -2px;
+}
+
+.column-drag-handle {
+  cursor: grab;
+  color: #adb5bd;
+  margin-right: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+th:hover .column-drag-handle {
+  opacity: 1;
+}
+
+.column-drag-handle:hover {
+  color: #0d6efd;
+}
+
 .fadeToWhite {
   background: -moz-linear-gradient(left, rgba(83, 80, 86, 0) 0%, rgba(83, 80, 86, 0.6) 100%); /* FF3.6-15 */
   background: -webkit-linear-gradient(left, rgba(83, 80, 86, 0) 0%, rgba(83, 80, 86, 0.6) 100%); /* Chrome10-25,Safari5.1-6 */


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1877)
- - -
<!-- Reviewable:end -->
## What this does

Two quality-of-life improvements to the collection view table headers:

### 1. Columns can be reordered by drag-and-drop

- a drag handle appears on the left of each column header when hovering it
- dragging it over another column moves the whole column (header + cells) there, with a visual drop indicator
- the order is persisted **per database/collection** in the browser's `localStorage` (key `mongo-express:columnOrder:<db>/<collection>`) and is re-applied on every page load — it survives searches, sorting and pagination
- columns not present in the saved order (new fields) keep their natural position at the end
- purely client-side: no server or API change

The drag only starts from the dedicated handle, on purpose: making the whole `<th>` draggable would swallow the `click` event on any slight mouse movement and break click-to-sort.


<img width="954" height="167" alt="image" src="https://github.com/user-attachments/assets/d873ccf1-12a0-493c-8ad1-7b74d0a6eb77" />

<img width="961" height="242" alt="image" src="https://github.com/user-attachments/assets/8010030e-eab2-4caa-874e-05e7ed76385d" />


### 2. Clearer sort affordance

- every column now always shows a sort icon: dimmed when the column is not sorted, highlighted up/down arrow when it is — previously nothing indicated that headers are clickable until a column was sorted
- headers no longer wrap on several lines when a column name is short and the sort icon used to overflow (`white-space: nowrap`)
- header text is not selectable anymore (`user-select: none`), which previously interfered with click-to-sort (a click that selected text was ignored)

Before, arrow was on 2 lines
<img width="174" height="92" alt="image" src="https://github.com/user-attachments/assets/ac53d67f-b1ed-40b1-817c-55b5900e493f" />
After, arrow is always on same line
<img width="258" height="52" alt="image" src="https://github.com/user-attachments/assets/6a13eb80-528d-4011-8e3a-64226ef6f737" />

## How to verify

1. Open any collection
2. Hover a column header → a drag handle appears; drag it onto another column → the column moves
3. Reload the page, navigate, search, sort → the custom column order is kept
4. Open the same collection in another browser/profile → default order (storage is local)
5. Click headers → sorting still works exactly as before