### PR TITLE
fix: remove stray space in the export links' projection param

### DIFF
--- a/lib/views/collection.html
+++ b/lib/views/collection.html
@@ -306,21 +306,21 @@
     <div class="row">
       {% if !settings.me_no_export %}
       <div class="col-sm-4 p-2 d-grid ">
-        <a href="{{ dbUrl }}/export/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"
+        <a href="{{ dbUrl }}/export/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection={{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"
           class="btn btn-warning btn-block text-white">
           <i class="fa fa-download d-block"></i>Export Standard
         </a>
       </div>
 
       <div class="col-sm-4 p-2 d-grid ">
-        <a href="{{ dbUrl }}/expArr/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"
+        <a href="{{ dbUrl }}/expArr/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection={{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"
           class="btn btn-warning btn-block text-white">
           <i class="fa fa-download d-block"></i>Export --jsonArray
         </a>
       </div>
 
       <div class="col-sm-4 p-2 d-grid ">
-        <a href="{{ dbUrl }}/expCsv/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection= {{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"
+        <a href="{{ dbUrl }}/expCsv/{{ collectionName | url_encode }}?key={{ key }}&value={{ value }}&type={{ type }}&query={{ query | url_encode }}&projection={{ projection | url_encode }}{% for k, v in sort %}&sort[{{ k }}]={{ v }}{% endfor %}"
           class="btn btn-warning btn-block text-white">
           <i class="fa fa-download d-block"></i>Export --csv
         </a>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1897)
- - -
<!-- Reviewable:end -->
Follow-up to #1895, which fixed the same typo on the per-row delete form.

The three export links in `collection.html` (Standard / --jsonArray / --csv) build their href as `&projection= {{ projection | url_encode }}`, putting a literal space into the URL:

```
before: ...&query=&projection= %7BtestItem%3A1%7D
after:  ...&query=&projection=%7BtestItem%3A1%7D
```

**Impact is cosmetic.** Verified against the running app: the export endpoint returns an identical 200 and identical documents with or without the leading space, because `bson.toSafeBSON` tolerates it. But a raw space does not belong in an `href`, and it is the last instance of the typo in the file.

Whitespace-only change; no test added. `yarn lint` clean, 61 passing.