### PR TITLE
test: stop the ephemeral MongoDB servers so their data dirs are removed

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,6 +1,9 @@
 recursive: true
 reporter: dot
 exit: true
+# Root hooks that stop the ephemeral MongoDB servers, so `exit: true` does not kill the
+# process before their data directories are removed.
+require: ./test/rootHooks.js
 # The router specs spin up a mongodb-memory-server in their before hook, which can take
 # well over mocha's 2s default on a cold or loaded CI runner (it may still be fetching the
 # binary). A too-tight timeout made the whole suite fail on unrelated changes.

--- a/test/rootHooks.js
+++ b/test/rootHooks.js
@@ -1,0 +1,12 @@
+// mocha looks up the root hooks by the named `mochaHooks` export; a default export is not
+// picked up, so the single-export rule does not apply here.
+/* eslint-disable import/prefer-default-export */
+import { stopMemoryServers } from './testMongoUtils.js';
+
+// Mocha root hooks: this runs once, after every spec file, and is the only place that can
+// stop the ephemeral MongoDB servers before `exit: true` kills the process.
+export const mochaHooks = {
+  async afterAll() {
+    await stopMemoryServers();
+  },
+};

--- a/test/testMongoUtils.js
+++ b/test/testMongoUtils.js
@@ -76,3 +76,17 @@ export const initializeDb = () => createConnection()
 export const initializeDbWithWrongAuth = () => createConnectionWithWrongAuth();
 export const cleanAndCloseDb = (client) => dropTestCollection(client)
   .then(() => closeDb(client));
+
+/**
+ * Shut the ephemeral MongoDB servers down and delete their data directories.
+ *
+ * Without this, `exit: true` tears the process down before mongodb-memory-server can clean
+ * up, leaving a ~200 MB dbpath under the temp dir on every run. On a developer machine
+ * those pile up until the disk (a 15 GB tmpfs here) is full and mongod starts failing to
+ * boot with an opaque `fassert() failure`.
+ */
+export const stopMemoryServers = async () => {
+  await Promise.all([mongod?.stop(), mongoauthd?.stop()]);
+  mongod = undefined;
+  mongoauthd = undefined;
+};


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1898)
- - -
<!-- Reviewable:end -->
mocha runs with `exit: true`, which tears the process down before mongodb-memory-server can clean up. Every run leaves a ~200 MB dbpath behind under the temp dir.

They accumulate silently on developer machines until the disk fills and mongod starts failing to boot with an opaque `fassert() failure`. That is exactly how it surfaced while working on #1876: 92 stale directories had filled a 15 GB tmpfs, and the suite looked broken — reproducibly, 59 passing / 10 failing — when nothing was wrong with the code.

Adds a mocha root hook that stops both memory servers (the plain one and the auth one used by `loginSpec`) after the last spec file, plus a `stopMemoryServers()` helper in `testMongoUtils`.

Verified by counting the temp directories around a run:

| | left behind |
|---|---|
| before | 2 dirs, ~400 MB per run |
| after | 0, across four consecutive runs |

No orphaned `mongod` processes either. Lint clean, 89 passing.