### PR TITLE
chore: drop EOL Node versions, support 24 and 26

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Install modules
         run: yarn install

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [18, 20, 22.4.1]
+        node: [22, 24, 26]
         os: [ubuntu-latest]
     name: Node v${{ matrix.node }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.16 AS build
+FROM node:24-alpine3.24 AS build
 
 # Build argument for enabling OIDC support
 ARG ENABLE_OIDC=false
@@ -15,7 +15,7 @@ RUN if [ "$ENABLE_OIDC" = "true" ]; then \
     && yarn build \
     && rm -rf /dockerbuild/lib/scripts
 
-FROM node:18-alpine3.16
+FROM node:24-alpine3.24
 
 # "localhost" doesn't mean much in a container, so we adjust our default to the common service name "mongo" instead
 # (and make sure the server listens outside the container, since "localhost" inside the container is usually difficult to access)
@@ -37,8 +37,8 @@ COPY --from=build /dockerbuild/.yarnrc.yml /opt/mongo-express/
 COPY --from=build /dockerbuild/.npmignore /opt/mongo-express/
 
 RUN apk -U add --no-cache \
-        bash=5.1.16-r2 \
-        tini=0.19.0-r0 \
+        bash=5.3.9-r1 \
+        tini=0.19.0-r3 \
     && yarn workspaces focus --production
 
 EXPOSE 8081

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Copy config.default.js to config.js and edit the default property to fit your lo
 
 ## Usage (npm / yarn / pnpm / CLI)
 
-_mongo-express_ requires Node.js v18.18 or higher.
+_mongo-express_ requires Node.js v22 or higher.
 
 **To install:**
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "uuid": "^11.1.1"
   },
   "engines": {
-    "node": ">=18.18"
+    "node": ">=22.0.0"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1899)
- - -
<!-- Reviewable:end -->
The CI matrix tested Node 18 and 20 — **both end-of-life** — and neither of the two current LTS lines.

| Node | Status | End |
|---|---|---|
| 18 | **EOL** | 2025-04-30 |
| 20 | **EOL** | 2026-04-30 |
| 22 | LTS | 2027-04-30 |
| 24 | LTS | 2028-04-30 |
| 26 | current, LTS in October | 2029-04-30 |

The published Docker image was in worse shape: it built on `node:18-alpine3.16` — an EOL runtime on an Alpine that went EOL in May 2024. That is what users actually run.

**Changes**

- CI matrix `[18, 20, 22.4.1]` → `[22, 24, 26]`. This also removes the `22.4.1` pin, which is the release carrying the `findPackageLocation` bug that #1598 set out to work around — that PR is a draft and this supersedes it.
- Dockerfile base → `node:24-alpine3.24`, staying on LTS for the shipped image. The `apk` pins had to move with it (`bash 5.1.16-r2` → `5.3.9-r1`, `tini 0.19.0-r0` → `0.19.0-r3`); those exact versions only exist in Alpine 3.16, so the build fails without it.
- `publish.yml` `22` → `24`, `engines` `>=18.18` → `>=22.0.0`, README line to match.

**Verified by actually building and running the image**, not just by CI:

- `node --version` inside the container → `v24.18.1`
- against a real `mongo:7` container → HTTP 200, databases listed, **zero errors** in the log
- with no URL configured → prints how to set one and exits 1, confirming the #1888 behaviour in a real container rather than a simulated non-TTY

Locally: lint clean, 89 passing.

**Note on scope:** `engines` moving to `>=22.0.0` is a support-policy change. Node 20 users would see an install warning. Both dropped versions are EOL, but flagging it explicitly since it affects users rather than just CI.

This also unblocks #1894, which currently fails only on Node 18: it bumps mongodb-memory-server to 11.2.0, which pulls the mongodb 7 driver, and that driver requires `node >=20.19.0`.