### PR TITLE
docs: add a docker-compose example with nginx

### DIFF
--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,0 +1,49 @@
+# Docker Compose example
+
+Runs MongoDB, mongo-express and nginx together, with nginx as the only published port.
+
+```console
+$ docker compose -f examples/docker-compose/compose.yaml up --build
+```
+
+Then open <http://localhost:8080> and log in with `admin` / `change-me-too`.
+
+Run it from the repository root. The build context in [compose.yaml](./compose.yaml) is
+relative to that file and points back at the repository, so the image is built from the
+working tree rather than pulled — which is what makes this useful for trying out a change.
+
+## What the pieces do
+
+`mongo` starts with a root user and a named volume, so data survives `docker compose down`.
+Its healthcheck gates startup: mongo-express waits for `service_healthy` rather than racing
+the database.
+
+`mongo-express` is built from this repository. It is reachable only from inside the compose
+network — `expose` rather than `ports` — so nginx is the only way in.
+
+`nginx` terminates the outside connection on port 8080 and proxies to mongo-express. Its
+config is in [nginx/default.conf](./nginx/default.conf).
+
+## Credentials
+
+Two separate sets, which is easy to conflate:
+
+- `ME_CONFIG_MONGODB_URL` carries the **MongoDB** credentials. It includes
+  `authSource=admin`, which the root user created by the official MongoDB image requires.
+- `ME_CONFIG_BASICAUTH_USERNAME` and `ME_CONFIG_BASICAUTH_PASSWORD` gate the **web
+  interface** only. They are not used to authenticate against MongoDB.
+
+The values in the file are placeholders. Replace them — including
+`ME_CONFIG_SITE_SESSIONSECRET`, which signs the session cookie — before running this
+anywhere that is not your laptop.
+
+## Notes on the nginx config
+
+`Host` and `X-Forwarded-Proto` are forwarded because mongo-express builds its own URLs from
+the incoming request; without them, links come back pointing at the container.
+
+`client_max_body_size` is raised to 64m. nginx defaults to 1m, which GridFS uploads hit
+quickly.
+
+`/status` is proxied separately with `access_log off`. The health check is served before
+mongo-express's authentication, so probes reach it without credentials.

--- a/examples/docker-compose/compose.yaml
+++ b/examples/docker-compose/compose.yaml
@@ -1,0 +1,55 @@
+# mongo-express behind nginx, building the image from this repository.
+#
+#   docker compose -f examples/docker-compose/compose.yaml up --build
+#
+# Then open http://localhost:8080. Run it from the repository root: the build context
+# below is relative to this file and points back at it.
+
+services:
+  mongo:
+    image: mongo:8
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ['CMD', 'mongosh', '--quiet', '--eval', 'db.adminCommand("ping")']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mongo-express:
+    build:
+      context: ../..
+    restart: unless-stopped
+    environment:
+      # authSource=admin is required for the root user the official image creates.
+      ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/?authSource=admin
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: 'true'
+      # Signs the session cookie. Replace this before using the stack for anything real.
+      ME_CONFIG_SITE_SESSIONSECRET: change-me
+      # Gates the web interface only; MongoDB credentials come from the URL above.
+      ME_CONFIG_BASICAUTH_ENABLED: 'true'
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: change-me-too
+    depends_on:
+      mongo:
+        condition: service_healthy
+    # Not published: nginx is the only way in.
+    expose:
+      - '8081'
+
+  nginx:
+    image: nginx:1-alpine
+    restart: unless-stopped
+    ports:
+      - '8080:80'
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - mongo-express
+
+volumes:
+  mongo-data:

--- a/examples/docker-compose/nginx/default.conf
+++ b/examples/docker-compose/nginx/default.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name _;
+
+    # The health check is served before authentication, so probes reach it without
+    # credentials while the rest of the interface stays behind basic auth.
+    location /status {
+        proxy_pass http://mongo-express:8081/status;
+        access_log off;
+    }
+
+    location / {
+        proxy_pass http://mongo-express:8081;
+        proxy_http_version 1.1;
+
+        # mongo-express builds its own URLs from the request, so the original host and
+        # scheme have to survive the hop or links come back pointing at the container.
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # File uploads to GridFS can be large; the default 1m is easy to hit.
+        client_max_body_size 64m;
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1901)
- - -
<!-- Reviewable:end -->
`examples/` already carries the Kubernetes manifests; this adds the compose equivalent — MongoDB, mongo-express and nginx, with nginx as the only published port.

```console
$ docker compose -f examples/docker-compose/compose.yaml up --build
```

**Written against the current app**, which is where #1796 came apart:

- **Builds from this repository** (`build: context: ../..`), so the stack exercises the working tree. #1796 pinned `image: mongo-express:1.0.0` from the registry, meaning it never touched this code at all.
- `ME_CONFIG_MONGODB_URL` with `authSource=admin`, required by the root user the official MongoDB image creates. #1796 used `ME_CONFIG_MONGODB_SERVER`, `_PORT`, `_ADMINUSERNAME` and `_ADMINPASSWORD` — none of which `config.default.js` reads, so it had no connection string.
- mongo-express is reachable only through nginx (`expose`, not `ports`), and waits on the database's healthcheck rather than racing it.
- nginx forwards `Host` and `X-Forwarded-Proto`, since mongo-express builds its own URLs from the request; raises `client_max_body_size` to 64m, which GridFS uploads hit against nginx's 1m default; and proxies `/status` separately with `access_log off`, because the health check is served ahead of authentication.

The README separates the two credential sets explicitly — `ME_CONFIG_MONGODB_URL` carries the MongoDB credentials, `ME_CONFIG_BASICAUTH_*` gate the web interface only — since conflating them is a recurring support question.

No changes to the Dockerfile, and no lockfiles touched.

**Verification, and its limit:** `docker compose config` resolves and the build context points at the repository root; `nginx -t` passes on the proxy config. I could **not** bring the full stack up on this machine — mongod fails to allocate its journal with the disk at 85% — so this is not verified running end to end. Worth someone doing before merge.

Idea from #1796 by @Mamoona-Ghania, which I closed with the reasoning above.