### PR TITLE
chore: pin yarn as the package manager and ignore npm lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ Thumbs.db
 
 # Node and related ecosystem
 # ==========================
+# This project is built with yarn; the vendored release in .yarn/releases and the
+# packageManager field are the source of truth. An npm lockfile here is always accidental,
+# and several pull requests have carried one by mistake.
+package-lock.json
+npm-shrinkwrap.json
 .nodemonignore
 .sass-cache/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "packageManager": "yarn@4.12.0",
   "license": "MIT",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1902)
- - -
<!-- Reviewable:end -->
The project is already committed to yarn — the release is vendored in `.yarn/releases` and `.yarnrc.yml` points at it — but nothing declares that where tooling can see it, and `package-lock.json` was never ignored.

**That has cost real review time.** Three pull requests carried an accidental npm lockfile:

| PR | `package-lock.json` |
|---|---|
| #1888 | 14,409 lines |
| #1796 | 13,692 lines |
| #1819 | 13,693 lines |

Nearly 42,000 lines of noise, each of which had to be spotted and stripped during review, and each of which buried the actual change — #1819's real diff was 342 lines under 13,693.

#1575 approached the same friction from the other side, proposing to keep `package-lock.json` in step with `yarn.lock` through a `postinstall` hook that runs npm. That cannot work: the hook re-triggers the tool that runs it, which is the loop its author left as an open TODO in June 2024, and `postinstall` in a published package also fires on the machines of anyone installing mongo-express as a dependency — which people do, since it is usable as middleware.

**Two lines close the class instead:**

- `packageManager: "yarn@4.12.0"`, so corepack selects the right tool without anyone having to know
- `package-lock.json` and `npm-shrinkwrap.json` in `.gitignore`

**Verified**, rather than assumed: creating an npm lockfile in the tree no longer shows up in `git status` (`git check-ignore` confirms the rule matches), and `yarn install --immutable` still passes with the version pinned. Lint clean, 135 tests passing.