### PR TITLE
fix: build redirect targets from configuration, not from the request

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -63,6 +63,11 @@ const buildId = function (id, query) {
 };
 
 const router = async function (config) {
+  // Redirect targets come from configuration, not from res.locals.baseHref: that is derived
+  // from req.originalUrl, so feeding it to res.redirect hands the caller influence over
+  // where other people get sent. CodeQL reports it as js/server-side-unvalidated-url-redirection.
+  const baseHref = config.site.baseUrl || '/';
+
   // appRouter configuration
   const appRouter = express.Router();
   let mongo = null;
@@ -259,7 +264,7 @@ const router = async function (config) {
     // Make sure database exists
     if (!mongo.connections[id]) {
       req.session.error = 'Database not found!';
-      return res.redirect(res.locals.baseHref);
+      return res.redirect(baseHref);
     }
 
     req.dbName = id;
@@ -277,7 +282,7 @@ const router = async function (config) {
 
     if (!mongo.collections[req.dbName].includes(id)) {
       req.session.error = 'Collection not found!';
-      return res.redirect(res.locals.baseHref + 'db/' + req.dbName);
+      return res.redirect(baseHref + 'db/' + req.dbName);
     }
 
     req.collectionName = id;
@@ -291,7 +296,7 @@ const router = async function (config) {
 
     if (coll === null) {
       req.session.error = 'Collection not found!';
-      return res.redirect(res.locals.baseHref + 'db/' + req.dbName);
+      return res.redirect(baseHref + 'db/' + req.dbName);
     }
 
     req.collection = coll;
@@ -303,7 +308,7 @@ const router = async function (config) {
   appRouter.param('document', async function (req, res, next, id) {
     if (id === 'undefined' || id === undefined) {
       req.session.error = 'Document lacks an _id!';
-      return res.redirect(res.locals.baseHref + 'db/' + req.dbName + '/' + req.collectionName);
+      return res.redirect(baseHref + 'db/' + req.dbName + '/' + req.collectionName);
     }
 
     id = JSON.parse(decodeURIComponent(id));
@@ -329,7 +334,7 @@ const router = async function (config) {
       req.session.error = 'Error: ' + error;
       console.error(error);
     }
-    res.redirect(res.locals.baseHref + 'db/' + req.dbName + '/' + req.collectionName);
+    res.redirect(baseHref + 'db/' + req.dbName + '/' + req.collectionName);
   });
 
   // get individual property - for async loading of big documents
@@ -356,9 +361,7 @@ const router = async function (config) {
       req.connFiles = await filesConn.find().toArray();
     } catch (error) {
       req.session.error = id + '.files collection not found! Err:' + error;
-      // config.site.baseUrl rather than res.locals.baseHref: the latter is derived from
-      // req.originalUrl, which CodeQL flags as request-controlled data reaching res.redirect.
-      return res.redirect((config.site.baseUrl || '/') + 'db/' + req.dbName);
+      return res.redirect(baseHref + 'db/' + req.dbName);
     }
 
     next();
@@ -395,7 +398,7 @@ const router = async function (config) {
    * res.redirect. config.site.baseUrl is server configuration the caller cannot influence.
    */
   appRouter.use(function (req, res, next) {
-    const safeRedirect = () => res.redirect(config.site.baseUrl || '/');
+    const safeRedirect = () => res.redirect(baseHref);
 
     if (config.options.readOnly && ['POST', 'PUT', 'DELETE'].includes(req.method)) {
       req.session.error = 'Application is running in read-only mode!';

--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -82,6 +82,11 @@ const RAW_COMMAND_EXAMPLE = 'Example: updateOne({name: "a"}, {$set: {name: "b"}}
 const RAW_COMMAND_PATTERN = /^\s*([A-Za-z][A-Za-z\d]*)\s*\(([\S\s]*)\)\s*$/;
 
 const routes = function (config) {
+  // Redirect targets come from configuration, not from res.locals.baseHref: that is derived
+  // from req.originalUrl, so feeding it to res.redirect hands the caller influence over
+  // where other people get sent. CodeQL reports it as js/server-side-unvalidated-url-redirection.
+  const baseHref = config.site.baseUrl || '/';
+
   const exp = {};
 
   /*
@@ -522,14 +527,14 @@ const routes = function (config) {
         // we're just deleting some of the documents
         await req.collection.deleteMany(query).then((opRes) => {
           req.session.success = opRes.deletedCount + ' documents deleted from "' + req.collectionName + '"';
-          res.redirect(res.locals.baseHref + 'db/' + req.dbName + '/' + req.collectionName);
+          res.redirect(baseHref + 'db/' + req.dbName + '/' + req.collectionName);
         });
       } else {
         // no query means we're dropping the whole collection
         await req.collection.drop();
         await req.updateCollections(req.dbConnection);
         req.session.success = 'Collection  "' + req.collectionName + '" deleted!';
-        res.redirect(res.locals.baseHref + 'db/' + req.dbName);
+        res.redirect(baseHref + 'db/' + req.dbName);
       }
     } catch (error) {
       req.session.error = 'Something went wrong: ' + error;
@@ -562,7 +567,7 @@ const routes = function (config) {
   exp.updateCollections = async function (req, res) {
     await req.updateCollections(req.dbConnection).then(() => {
       req.session.success = 'Collections Updated!';
-      res.redirect(res.locals.baseHref + 'db/' + req.dbName);
+      res.redirect(baseHref + 'db/' + req.dbName);
     }).catch((error) => {
       req.session.error = 'Something went wrong: ' + error;
       console.error(error);

--- a/lib/routes/database.js
+++ b/lib/routes/database.js
@@ -1,6 +1,11 @@
 import * as utils from '../utils.js';
 
 const routes = function (config) {
+  // Redirect targets come from configuration, not from res.locals.baseHref: that is derived
+  // from req.originalUrl, so feeding it to res.redirect hands the caller influence over
+  // where other people get sent. CodeQL reports it as js/server-side-unvalidated-url-redirection.
+  const baseHref = config.site.baseUrl || '/';
+
   const exp = {};
 
   exp.viewDatabase = async function (req, res) {
@@ -59,11 +64,11 @@ const routes = function (config) {
 
     await ndb.createCollection('delete_me').then(async () => {
       await req.updateDatabases().then(() => {
-        res.redirect(res.locals.baseHref);
+        res.redirect(baseHref);
       });
 
       // await ndb.dropCollection('delete_me').then(() => {
-      //   res.redirect(res.locals.baseHref + 'db/' + name);
+      //   res.redirect(baseHref + 'db/' + name);
       // }).catch((error) => {
       //   //TODO: handle error
       //   console.error('Could not delete collection.');
@@ -80,7 +85,7 @@ const routes = function (config) {
 
   exp.deleteDatabase = async function (req, res) {
     await req.db.dropDatabase().then(async () => {
-      await req.updateDatabases().then(() => res.redirect(res.locals.baseHref));
+      await req.updateDatabases().then(() => res.redirect(baseHref));
     }).catch((error) => {
       // TODO: handle error
       console.error('Could not to delete database. Err:' + error);

--- a/test/lib/routers/redirectSpec.js
+++ b/test/lib/routers/redirectSpec.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+
+import defaultConf from '../../testDefaultConfig.js';
+import middleware from '../../../lib/middleware.js';
+import {
+  cleanAndCloseDb, initializeDb, testDbName as dbName,
+} from '../../testMongoUtils.js';
+
+// Redirect targets are built from config.site.baseUrl, not from res.locals.baseHref, which
+// is derived from req.originalUrl. Feeding request-derived data to res.redirect is what
+// CodeQL reports as js/server-side-unvalidated-url-redirection, and it is how an attacker
+// gets a foothold on where other people are sent.
+const serverWith = async (overrides = {}) => {
+  const config = defaultConf();
+  Object.assign(config.site, overrides);
+  const app = await middleware(config);
+  const httpServer = app.listen();
+
+  return { request: supertest.agent(httpServer), close: () => httpServer.close() };
+};
+
+const withServer = async (overrides, body) => {
+  const server = await serverWith(overrides);
+  try {
+    return await body(server.request);
+  } finally {
+    server.close();
+  }
+};
+
+describe('Redirect targets', () => {
+  let client;
+
+  before(() => initializeDb().then((newClient) => { client = newClient; }));
+  after(() => cleanAndCloseDb(client));
+
+  describe('follow the configured base', () => {
+    it('a missing database goes to the root', () => withServer({}, async (request) => {
+      const res = await request.get('/db/does-not-exist').expect(302);
+      expect(res.headers.location).to.equal('/');
+    }));
+
+    it('a missing collection goes to its database', () => withServer({}, async (request) => {
+      const res = await request.get(`/db/${dbName}/does-not-exist`).expect(302);
+      expect(res.headers.location).to.equal(`/db/${dbName}`);
+    }));
+
+    it('honours a configured baseUrl', () => withServer({ baseUrl: '/mongo/' }, async (request) => {
+      const res = await request.get('/db/does-not-exist').expect(302);
+      expect(res.headers.location).to.equal('/mongo/');
+    }));
+  });
+
+  describe('ignore the request when choosing where to send people', () => {
+    // These paths do not resolve to a route, so nothing should redirect off-host. The point
+    // is that the target never picks up anything the caller supplied.
+    for (const attempt of [
+      '//evil.example.com/db/does-not-exist',
+      '/%2f%2fevil.example.com/db/does-not-exist',
+      '/db/does-not-exist/../..//evil.example.com',
+    ]) {
+      it(`does not send the visitor off-host for ${attempt}`, () => withServer({}, async (request) => {
+        const res = await request.get(attempt);
+        const location = res.headers.location;
+
+        if (location) {
+          expect(location).to.not.contain('evil.example.com');
+          expect(location.startsWith('/'), `absolute or protocol-relative target: ${location}`).to.equal(true);
+          expect(location.startsWith('//')).to.equal(false);
+        }
+      }));
+    }
+  });
+});


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1903)
- - -
<!-- Reviewable:end -->
Closes the open-redirect alerts on master: **#42** (`lib/routes/database.js:62`, the one raised here) plus **#7**, **#8**, **#9** and **#10** in `lib/router.js`.

All of them are the same shape. `res.locals.baseHref` comes from `buildBaseHref(req.originalUrl, req.url)` — request-derived data reaching `res.redirect`, which is what CodeQL reports as `js/server-side-unvalidated-url-redirection`. It gives the caller a hand in where other people get sent.

All ten redirects across `router.js`, `routes/database.js` and `routes/collection.js` now use `config.site.baseUrl`. The two one-off fixes of the same kind made along the way in #1900 and #1811 are folded into the same helper rather than left as separate spellings.

**Left alone deliberately:** the other uses of `res.locals.baseHref` build hrefs rendered into templates, not `Location` headers. Those should keep reflecting how the app was actually reached, or links break behind a proxy.

**One wrinkle worth knowing:** `config.site.baseUrl` needs the `|| '/'` fallback. Only `config.default.js` supplies a value, and `app.js` patches it in at startup — so `middleware()` called directly, as the tests do, sees `undefined`. Without the fallback this would have shipped `res.redirect(undefined)`.

**Verified the behaviour is unchanged**, comparing targets before and after the change:

| | before | after |
|---|---|---|
| missing database | `/` | `/` |
| missing collection | `/db/<db>` | `/db/<db>` |
| missing document | `/db/<db>/<collection>` | `/db/<db>/<collection>` |

Adds `test/lib/routers/redirectSpec.js`: that a configured `baseUrl` is honoured — which fails if the request-derived value is put back — and that paths shaped like `//evil.example.com` never yield an off-host `Location`.

Lint clean, 141 tests passing.