### PR TITLE
fix: make the multi-connection config reachable, and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,41 @@ ME_CONFIG_SITE_BASEURL=/<base-url>
 
 To register your client, you will need the application's redirect URI, which can be obtained by appending `/callback` to the application base URL: Eg. https://example.com/mongo-express/callback
 
+## Connecting to more than one database
+
+A single connection already exposes every database on that server, provided admin access is
+on — set `ME_CONFIG_MONGODB_ENABLE_ADMIN=true`, or `mongodb.admin` in `config.js`. Without
+it, only the database named in the connection string is listed.
+
+To reach databases on **separate MongoDB servers**, give `mongodb` a list of connections
+instead of a single one. This needs a `config.js`: the environment variables describe one
+connection only.
+
+```js
+// config.js
+export default {
+  mongodb: [
+    {
+      connectionString: 'mongodb://user:pass@mongo-a:27017/?authSource=admin',
+      connectionName: 'reporting',
+      admin: true,
+    },
+    {
+      connectionString: 'mongodb://user:pass@mongo-b:27017/orders',
+      connectionName: 'orders',
+    },
+  ],
+};
+```
+
+With more than one connection, databases are listed as `<connectionName>_<databaseName>` —
+`reporting_analytics`, `orders_orders` and so on — so that databases sharing a name across
+servers stay distinct. `connectionName` is optional and defaults to `connection0`,
+`connection1`, and so on, which is rarely what you want to read in the interface.
+
+Each entry takes the same keys as the single-connection form, so `admin`, `whitelist`,
+`blacklist` and `connectionOptions` can differ per server.
+
 ## Search
 
 - _Simple_ search takes the user provided fields (`key` & `value`) and prepares a MongoDB find() object, with projection set to `{}` so returns all columns.

--- a/app.js
+++ b/app.js
@@ -40,8 +40,15 @@ const loadConfig = async () => {
   }
 };
 
+// config.mongodb is either one connection or a list of them; lib/db.js accepts both.
+// Checking `.connectionString` on the list form finds undefined and wrongly reports that
+// nothing is configured, which kept multi-connection setups from starting at all.
+const hasConnectionString = (mongodb) => (Array.isArray(mongodb)
+  ? mongodb.some((connection) => connection?.connectionString)
+  : Boolean(mongodb?.connectionString));
+
 async function bootstrap(config) {
-  if (!config.mongodb.connectionString) {
+  if (!hasConnectionString(config.mongodb)) {
     // Only prompt when someone is there to answer. Under Docker, systemd or CI stdin is not
     // a TTY, and blocking on it would hang the process instead of reporting the problem.
     if (!process.stdin.isTTY) {
@@ -52,7 +59,8 @@ async function bootstrap(config) {
 
     console.log(pico.yellow('\nNo MongoDB connection string configured.'));
     try {
-      config.mongodb.connectionString = await promptForConnectionString();
+      // Only meaningful for the single-connection form; a list that reached here is empty.
+      config.mongodb = { ...config.mongodb, connectionString: await promptForConnectionString() };
     } catch (error) {
       console.error(pico.red(`\n${error.message}`));
       return process.exit(1);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,11 @@ export const colsToGrid = function (cols) {
 
 export const deepmerge = function (target, src) {
   if (Array.isArray(src)) {
-    const dst = [...(target || [])];
+    // An array in the source replaces a non-array target instead of merging into it.
+    // Spreading a plain object here threw "(target || []) is not iterable", which is what
+    // stopped config.mongodb from being written as a list of connections: config.default.js
+    // declares it as an object, so any config.js using the array form crashed on load.
+    const dst = Array.isArray(target) ? [...target] : [];
     for (const [i, e] of src.entries()) {
       if (dst[i] === undefined) {
         dst[i] = e;

--- a/test/lib/multiConnectionSpec.js
+++ b/test/lib/multiConnectionSpec.js
@@ -1,0 +1,64 @@
+import { MongoClient } from 'mongodb';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { expect } from 'chai';
+import supertest from 'supertest';
+
+import middleware from '../../lib/middleware.js';
+import { deepmerge } from '../../lib/utils.js';
+import configDefault from '../../config.default.js';
+
+// config.mongodb may be a single connection or a list of them (lib/db.js splits on
+// Array.isArray). The list form was unreachable in practice: config.default.js declares
+// mongodb as an object, and deepmerge threw "(target || []) is not iterable" when a
+// config.js overrode it with an array, so the app refused to start.
+describe('Multiple connections', () => {
+  let first;
+  let second;
+  let server;
+
+  before(async () => {
+    [first, second] = await Promise.all([MongoMemoryServer.create(), MongoMemoryServer.create()]);
+
+    await Promise.all([[first, 'sales'], [second, 'orders']].map(async ([instance, dbName]) => {
+      const client = await MongoClient.connect(instance.getUri());
+      await client.db(dbName).collection('items').insertOne({ probe: true });
+      await client.close();
+    }));
+  });
+
+  after(async () => {
+    if (server) {
+      server.close();
+    }
+    await Promise.all([first?.stop(), second?.stop()]);
+  });
+
+  it('merges a list of connections over the default single one', () => {
+    const merged = deepmerge(configDefault, {
+      mongodb: [{ connectionString: 'mongodb://a' }, { connectionString: 'mongodb://b' }],
+    });
+
+    expect(Array.isArray(merged.mongodb)).to.equal(true);
+    expect(merged.mongodb).to.have.lengthOf(2);
+  });
+
+  it('serves databases from every connection, prefixed by connection name', async () => {
+    const config = deepmerge(configDefault, {
+      mongodb: [
+        { connectionString: `${first.getUri()}sales`, connectionName: 'primary' },
+        { connectionString: `${second.getUri()}orders`, connectionName: 'secondary' },
+      ],
+      site: { sessionSecret: 'sessionsecret', cookieSecret: 'cookiesecret' },
+      options: { console: false },
+    });
+
+    const app = await middleware(config);
+    server = app.listen();
+
+    const res = await supertest(server).get('/').expect(200);
+
+    // With more than one client, db.js keys databases as `${connectionName}_${dbName}`.
+    expect(res.text).to.contain('primary_sales');
+    expect(res.text).to.contain('secondary_orders');
+  });
+});


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1904)
- - -
<!-- Reviewable:end -->
Closes #1787.

The issue asks for documentation on connecting to more than one database. Writing it turned up why the earlier attempt (#1790) could not be followed by the person who opened the issue: **the feature was unreachable**.

`lib/db.js` has always accepted a list of connections —

```js
const connections = Array.isArray(config.mongodb) ? config.mongodb : [config.mongodb];
```

— and keys databases as `${connectionName}_${dbName}` once there is more than one. But `config.default.js` declares `mongodb` as an object, and two things stood between that and a working setup:

| | |
|---|---|
| `deepmerge` threw `(target || []) is not iterable` | a `config.js` overriding the object with an array made the app refuse to load it: **"Unable to load config.js!"** |
| the startup guard read `config.mongodb.connectionString` | `undefined` on the list form, so it reported no connection string and exited — that one is mine, from #1888 |

Both fixed, and only then documented. The order matters: the previous documentation described something that could not work, which is why the reporter came back saying it did not match `config.default.js`.

**Verified end to end**, running `app.js` against two ephemeral servers with the `config.js` exactly as written in the new README section:

```
ARRANQUE>>> OK
BASES>>> orders_orders reporting_analytics
```

The README section explains the two cases that were being conflated in the issue thread — several databases on one server (`ME_CONFIG_MONGODB_ENABLE_ADMIN`) versus several servers (the list form, which needs a `config.js` because the environment variables describe one connection only) — and the `<connectionName>_<databaseName>` naming, which is otherwise surprising.

Adds `test/lib/multiConnectionSpec.js`: the merge itself, and that databases from both connections are served under their prefixed names. Both fail without the `deepmerge` fix.

`deepmerge` had no test coverage at all before this.

Lint clean, 137 tests passing.