### PR TITLE
fix: report an unreachable database, and stop the read-only Back button submitting

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -4,6 +4,7 @@ import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import errorHandler from 'errorhandler';
 import express from 'express';
+import pico from 'picocolors';
 import favicon from 'serve-favicon';
 import logger from 'morgan';
 import methodOverride from 'method-override';
@@ -69,11 +70,21 @@ const router = async function (config) {
   try {
     mongo = await db(config);
   } catch (error) {
-    console.debug(error);
+    // console.debug hid this: the process carried on and the only sign was a debug line most
+    // people never see. The app still starts, so the connection form can be used to supply
+    // working credentials, but the failure itself is worth saying out loud.
+    console.error(pico.red('Could not connect to MongoDB on startup.'));
+    console.error(error);
   }
 
   appRouter.get(config.healthCheck.path, (req, res) => {
-    res.json({ status: 'ok' });
+    // Reporting ok while unable to reach MongoDB makes the check useless: an orchestrator
+    // sees a healthy container, so it neither restarts it nor takes it out of rotation.
+    if (mongo === null) {
+      return res.status(503).json({ status: 'error', error: 'No MongoDB connection' });
+    }
+
+    return res.json({ status: 'ok' });
   });
 
   // The form strategy gates requests further down, once sessions exist; basic auth can stay

--- a/lib/views/document.html
+++ b/lib/views/document.html
@@ -83,7 +83,10 @@
           Save
         </button>
       {% else %}
-        <button onclick="return history.back()" class="btn btn-warning btn-large btn-block">
+        {# type="button" matters: this sits inside the POST form, and a button without it
+   defaults to submit. history.back() returns undefined, which does not cancel the
+   submission, so the page both navigated back and posted the form. #}
+        <button type="button" onclick="history.back()" class="btn btn-warning btn-large btn-block">
           <i class="fa fa-arrow-left"></i>
           Back
         </button>
@@ -108,7 +111,10 @@
         Save
       </button>
     {% else %}
-      <button onclick="return history.back()" class="btn btn-warning btn-large btn-block">
+      {# type="button" matters: this sits inside the POST form, and a button without it
+   defaults to submit. history.back() returns undefined, which does not cancel the
+   submission, so the page both navigated back and posted the form. #}
+        <button type="button" onclick="history.back()" class="btn btn-warning btn-large btn-block">
         <i class="fa fa-arrow-left"></i>
         Back
       </button>

--- a/test/lib/routers/healthCheckSpec.js
+++ b/test/lib/routers/healthCheckSpec.js
@@ -45,6 +45,15 @@ describe('Router health check', () => {
     await request.get('/status').expect(404);
   }));
 
+  // Regression for #1671: reporting ok while unable to reach MongoDB made the check useless,
+  // since an orchestrator saw a healthy container and left a broken one running.
+  it('reports 503 when there is no MongoDB connection', () => withServer({
+    mongodb: { connectionString: 'mongodb://127.0.0.1:1/?serverSelectionTimeoutMS=250' },
+  }, async (request) => {
+    const res = await request.get('/status').expect(503);
+    expect(res.body.status).to.equal('error');
+  }));
+
   it('does not require basic auth, so probes work on a protected instance', () => withServer({
     useBasicAuth: true,
     basicAuth: { username: 'probe-user', password: 'probe-pass' },

--- a/test/lib/routers/readOnlySpec.js
+++ b/test/lib/routers/readOnlySpec.js
@@ -73,6 +73,22 @@ describe('Router read-only and no-delete enforcement', () => {
       .get(`/db/${dbName}/${urlColName}`).expect(200)));
   });
 
+  // Regression for #1712: the read-only Back button sits inside the POST form, and a button
+  // without an explicit type defaults to submit. history.back() returns undefined, which
+  // does not cancel the submission, so clicking Back also posted the form. The editable path
+  // was never affected: its handler returns false.
+  it('renders a Back button that cannot submit the form', () => withProbeDocument({ readOnly: true }, async (request, _id) => {
+    const res = await request
+      .get(`/db/${dbName}/${urlColName}/${JSON.stringify(_id.toString())}`).expect(200);
+
+    const backButtons = res.text.match(/<button[^>]*history\.back\(\)[^>]*>/g) || [];
+
+    expect(backButtons, 'no read-only Back button rendered').to.not.have.lengthOf(0);
+    for (const button of backButtons) {
+      expect(button, `Back button without type="button": ${button}`).to.contain('type="button"');
+    }
+  }));
+
   describe('noDelete', () => {
     it('refuses to delete a document', () => withProbeDocument({ noDelete: true }, async (request, _id) => {
       await deleteDocument(request, _id);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1905)
- - -
<!-- Reviewable:end -->
Two issues found while triaging. Closes #1671 and #1712.

## #1671 — the health check said ok while the database was unreachable

```js
try { mongo = await db(config); } catch (error) { console.debug(error); }
```

A startup failure was swallowed into `console.debug`, and the health check returned `ok` unconditionally. Reproduced against an unreachable server:

| | before | after |
|---|---|---|
| `/status` | **200** `{"status":"ok"}` | **503** `{"status":"error","error":"No MongoDB connection"}` |
| log | debug line most people never see | `Could not connect to MongoDB on startup` at error level |

That combination is what the issue is really about: a container with no database reports healthy, so nothing restarts it and nothing takes it out of rotation.

The app still starts, so the runtime connection form can be used to supply working credentials — the check reflects the state rather than forcing an exit.

**Known limit:** this reports whether a connection was ever established. It does not ping on every probe, so a database that disappears later is not detected. Making the check active is a separate decision, since it puts a round trip on every probe.

## #1712 — the read-only Back button also submitted the form

```html
<button onclick="return history.back()" ...>
```

It sits inside the POST form in `document.html`, and a `<button>` without an explicit `type` defaults to `submit`. `history.back()` returns `undefined`, which does not cancel the submission — so the click navigated back *and* posted. Fixed with `type="button"` on both occurrences.

Worth noting the editable path was never affected, which is why the issue only shows up with `ME_CONFIG_OPTIONS_READONLY`: `onBackClick()` returns `false` explicitly.

## Verification

Both regressions are covered, and both new cases fail when the fixes are undone — reverting the two changes takes the suite from 137 passing to 135 passing, 2 failing.

Lint clean.