### PR TITLE
fix: export the aggregate result, not a broken find()

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -371,20 +371,44 @@ const routes = function (config) {
     res.redirect(req.get('Referrer') || '/');
   };
 
+  /**
+   * Cursor over whatever the collection view is currently showing.
+   *
+   * The exports used to hand _getQuery()'s result straight to find(). With the Aggregate
+   * checkbox ticked that result is a pipeline array, and find() rejects it with
+   * "Query filter must be a plain object or ObjectId" — thrown inside the cursor stream,
+   * so the surrounding try/catch never saw it.
+   */
+  exp._getExportCursor = function (req) {
+    const query = exp._getQuery(req);
+    const queryOptions = {
+      sort: exp._getSort(req),
+      projection: exp._getProjection(req),
+    };
+
+    if (req.query.runAggregate === 'on' && Array.isArray(query)) {
+      const pipeline = [
+        ...query,
+        ...(Object.keys(queryOptions.sort).length > 0 ? [{ $sort: queryOptions.sort }] : []),
+        ...(Object.keys(queryOptions.projection).length > 0 ? [{ $project: queryOptions.projection }] : []),
+      ];
+
+      return req.collection.aggregate(pipeline, { allowDiskUse: config.mongodb.allowDiskUse });
+    }
+
+    return req.collection.find(query, queryOptions);
+  };
+
   exp.exportCollection = async function (req, res) {
     try {
-      const query = exp._getQuery(req);
-      const queryOptions = {
-        sort: exp._getSort(req),
-        projection: exp._getProjection(req),
-      };
+      const cursor = exp._getExportCursor(req);
       res.setHeader(
         'Content-Disposition',
         'attachment; filename="' + encodeURI(req.collectionName) + '.json"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)
         + '.json',
       );
       res.setHeader('Content-Type', 'application/json');
-      await req.collection.find(query, queryOptions).stream({
+      await cursor.stream({
         transform(item) {
           return bson.toJsonString(item);
         },
@@ -398,12 +422,8 @@ const routes = function (config) {
 
   exp.exportColArray = async function (req, res) {
     try {
-      const query = exp._getQuery(req);
-      const queryOptions = {
-        sort: exp._getSort(req),
-        projection: exp._getProjection(req),
-      };
-      await req.collection.find(query, queryOptions).toArray().then((items) => {
+      const cursor = exp._getExportCursor(req);
+      await cursor.toArray().then((items) => {
         res.setHeader(
           'Content-Disposition',
           'attachment; filename="' + encodeURI(req.collectionName) + '.json"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)
@@ -422,12 +442,8 @@ const routes = function (config) {
 
   exp.exportCsv = async function (req, res) {
     try {
-      const query = exp._getQuery(req);
-      const queryOptions = {
-        sort: exp._getSort(req),
-        projection: exp._getProjection(req),
-      };
-      await req.collection.find(query, queryOptions).toArray().then((items) => {
+      const cursor = exp._getExportCursor(req);
+      await cursor.toArray().then((items) => {
         res.setHeader(
           'Content-Disposition',
           'attachment; filename="' + encodeURI(req.collectionName) + '.csv"; filename*=UTF-8\'\'' + encodeURI(req.collectionName)

--- a/test/lib/routers/collectionSpec.js
+++ b/test/lib/routers/collectionSpec.js
@@ -169,6 +169,36 @@ describe('Router collection', () => {
       expect(res.headers['content-type']).to.equal('text/csv');
     }));
 
+  // Regression for #1674: with the Aggregate box ticked, the exports passed the pipeline
+  // array to find() as a filter. MongoDB rejected it with "Query filter must be a plain
+  // object or ObjectId", thrown inside the cursor stream where the try/catch could not see it.
+  describe('exports with an aggregate query', () => {
+    const pipeline = '[{$match:{testItem:1}}]';
+
+    it('json export returns the matching document', () => request
+      .get(`/db/${dbName}/export/${urlColName}`).query({ runAggregate: 'on', query: pipeline })
+      .expect(200).responseType('blob')
+      .then((res) => {
+        expect(res.body.toString()).to.contain('"testItem":1');
+      }));
+
+    it('array export returns the matching document', () => request
+      .get(`/db/${dbName}/expArr/${urlColName}`).query({ runAggregate: 'on', query: pipeline })
+      .expect(200).responseType('blob')
+      .then((res) => {
+        const items = JSON.parse(res.body.toString());
+        expect(items).to.have.lengthOf(1);
+        expect(items[0].testItem).to.equal(1);
+      }));
+
+    it('csv export returns the matching document', () => request
+      .get(`/db/${dbName}/expCsv/${urlColName}`).query({ runAggregate: 'on', query: pipeline })
+      .expect(200).responseType('blob')
+      .then((res) => {
+        expect(res.body.toString()).to.contain('testItem');
+      }));
+  });
+
   it('GET /db/<dbName>/dropIndex/<collection> should drop index');
   it('GET /db/<dbName>/updateCollections/<collection> should updateCollections');
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1906)
- - -
<!-- Reviewable:end -->
Closes #1674.

All three export endpoints — `export`, `expArr` and `expCsv` — handed `_getQuery()`'s result straight to `collection.find()`. With the **Aggregate** checkbox ticked that result is a pipeline array, and `find()` rejects it:

```
MongoInvalidArgumentError: Query filter must be a plain object or ObjectId
```

Reproduced against a real collection. Worth noting *how* it fails: the error is thrown inside the cursor stream rather than at the call site, so the `try/catch` wrapped around each handler never saw it — the request was left hanging instead of redirecting with a message.

`_getItemsAndCount` has always branched on `runAggregate` for the collection view. The exports never did. They now share `_getExportCursor()`, which runs the pipeline through `aggregate()` — carrying sort and projection as `$sort` and `$project` stages, matching what the view does — or falls back to `find()` exactly as before when the box is unticked.

Three regression tests, one per endpoint. All three fail without the fix (138 passing → 135 passing, 3 failing).

Lint clean.