### PR TITLE
[Release] v1.1.0-rc-5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-rc-4",
+  "version": "1.1.0-rc-5",
   "author": "https://github.com/mongo-express",
   "name": "mongo-express",
   "type": "module",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1907)
- - -
<!-- Reviewable:end -->
Bumps the version so a release candidate can be cut and published.

**Why an rc and not 1.1.0.** The 1.1 milestone has eight open items, five of which are fixes waiting on review — #1902 through #1906, including the open-redirect work in #1903 that closes five CodeQL alerts. Cutting 1.1.0 now would ship the milestone incomplete, and an npm version cannot be republished once it is out.

**What this unblocks.** #1765 has been open since June asking for a newer image on Docker Hub; the published one is `1.0.2-20-alpine3.19` from November 2024. Of the 150 open issues here, 18 are labelled as old-version problems and 8 report errors from `docker-entrypoint.sh` — a file that only exists in mongo-express-docker. An rc gives something current to build and test the image against.

**Note on the flow, for whoever runs the workflow:** `scripts/release.cjs` passes `prerelease: false`, so this will appear as a normal release on GitHub rather than a pre-release, and `npm publish` without a `--tag` will move `latest` to the rc. That matches how rc-1 through rc-4 were handled, so this changes nothing — but it is worth knowing rather than discovering.

**Still blocked after this**, for the record: `versions.sh` in mongo-express-docker selects upstream versions with `^1\.1\.[0-9]*$`, which does not match an rc. The official image still needs a final 1.1.0; this only unblocks manual builds against the `release/v1.1.0-rc-5` branch.