### PR TITLE
fix: import the files this app exports, and the ones other tools write

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -12,6 +12,119 @@ const ALLOWED_MIME_TYPES = new Set([
   'application/json',
 ]);
 
+/**
+ * Split a run of JSON values that sit next to each other, whether separated by newlines, as
+ * mongoexport writes them, or by nothing at all, which is what this app's own export wrote
+ * before #1225. Brackets are counted outside of strings, so punctuation inside a value never
+ * splits it. Anything between two values other than whitespace means the file is not a run of
+ * documents, and it is rejected rather than silently skipped.
+ */
+const splitAdjacentJsonValues = function (text) {
+  const values = [];
+  let depth = 0;
+  let start = -1;
+  let lastEnd = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const [index, char] of [...text].entries()) {
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"' && depth > 0) {
+      inString = true;
+      continue;
+    }
+
+    if (char === '{' || char === '[') {
+      if (depth === 0) {
+        if (text.slice(lastEnd, index).trim() !== '') {
+          throw new SyntaxError('Unexpected content between documents');
+        }
+        start = index;
+      }
+      depth += 1;
+      continue;
+    }
+
+    if (char === '}' || char === ']') {
+      depth -= 1;
+
+      if (depth < 0) {
+        throw new SyntaxError('Unbalanced brackets');
+      }
+
+      if (depth === 0) {
+        values.push(text.slice(start, index + 1));
+        lastEnd = index + 1;
+      }
+    }
+  }
+
+  if (depth !== 0) {
+    throw new SyntaxError('Unbalanced brackets');
+  }
+
+  if (text.slice(lastEnd).trim() !== '') {
+    throw new SyntaxError('Unexpected trailing content');
+  }
+
+  return values;
+};
+
+/**
+ * Import files arrive in more shapes than one document per line: an array from this app's own
+ * array export, one document per line from mongoexport, a single document, an array
+ * pretty-printed across many lines by Compass, and documents written back to back. Throws when
+ * the content is not readable as documents, which the caller turns into a 400.
+ */
+const parseImportedDocuments = function (text) {
+  const trimmed = text.trim();
+
+  if (trimmed === '') {
+    return [];
+  }
+
+  // Parsing the whole file first covers an array and a single document, and is the only thing
+  // that reads a pretty-printed one, whose lines are fragments on their own.
+  try {
+    const parsed = EJSON.parse(trimmed);
+
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    // Not a single JSON value, so read it as a run of adjacent ones below.
+  }
+
+  const docs = [];
+
+  for (const value of splitAdjacentJsonValues(trimmed)) {
+    const parsed = EJSON.parse(value);
+
+    // Use push rather than spread: a large array would overflow the stack.
+    if (Array.isArray(parsed)) {
+      for (const doc of parsed) {
+        docs.push(doc);
+      }
+    } else {
+      docs.push(parsed);
+    }
+  }
+
+  if (docs.length === 0) {
+    throw new SyntaxError('No documents found');
+  }
+
+  return docs;
+};
+
 const converters = {
   // If type == J, convert value as json document
   J(value) {
@@ -418,13 +531,18 @@ const routes = function (config) {
 
       // cursor.stream() took a transform option until driver 7 dropped it. Passing one now is
       // accepted and ignored, so raw documents reach the response and Node rejects the object
-      // chunk. Serialising in an explicit Transform keeps the output byte-for-byte the same.
+      // chunk, hence serialising in an explicit Transform.
+      //
+      // Each document ends with a newline. Without one they arrive glued together as
+      // {..}{..}{..}, which is neither JSON nor the newline-delimited format the menu entry
+      // promises, so nothing could read it back — not mongoimport, not Compass, not this
+      // app's own import. That is issue #1225.
       await pipeline(
         cursor.stream(),
         new Transform({
           objectMode: true,
           transform(item, encoding, callback) {
-            callback(null, bson.toJsonString(item));
+            callback(null, bson.toJsonString(item) + '\n');
           },
         }),
         res,
@@ -649,19 +767,16 @@ const routes = function (config) {
     const docs = [];
 
     for (const file of files) {
-      const fileContent = file.data.toString('utf8');
-      const lines = fileContent.split('\n').map((line) => line.trim()).filter(Boolean);
-      for (const line of lines) {
-        try {
-          const parsedData = EJSON.parse(line);
-          // Use for loop instead of spread to avoid stack overflow with large arrays
-          for (const doc of parsedData) {
-            docs.push(doc);
-          }
-        } catch (error) {
-          console.error(error);
-          return res.status(400).send('Bad file content');
+      try {
+        const parsed = parseImportedDocuments(file.data.toString('utf8'));
+
+        // Use push rather than spread: a large file would overflow the stack.
+        for (const doc of parsed) {
+          docs.push(doc);
         }
+      } catch (error) {
+        console.error(error);
+        return res.status(400).send('Bad file content');
       }
     }
     await req.collection.insertMany(docs).then((stats) => {

--- a/test/lib/routers/importSpec.js
+++ b/test/lib/routers/importSpec.js
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+
+import { createServer } from '../../testHttpUtils.js';
+import {
+  cleanAndCloseDb, initializeDb, testCollection,
+  testDbName as dbName, testURLCollectionName as urlColName,
+} from '../../testMongoUtils.js';
+
+// Issue #1225, open since 2023: mongo-express could not import its own export. Three separate
+// defects met there. The export wrote documents glued together with no separator, so the file
+// was neither JSON nor the newline-delimited format the menu entry offers. The import read one
+// line at a time, which fails on anything pretty-printed, and iterated each parsed line as an
+// array, which throws on a plain document. Between them, the only shape that ever imported was
+// a single-line array — this app's own array export, and nothing else.
+const importFile = (request, body) => request
+  .post(`/db/${dbName}/import/${urlColName}`)
+  .attach('file', Buffer.from(body), { filename: 'import.json', contentType: 'application/json' });
+
+const accepted = {
+  'an array on one line': ['[{"imported":1},{"imported":2}]', 2],
+  'one document per line, as mongoexport writes': ['{"imported":1}\n{"imported":2}\n', 2],
+  'a single document': ['{"imported":1}', 1],
+  'an array pretty-printed across lines, as Compass writes': ['[\n  {\n    "imported": 1\n  }\n]', 1],
+  'documents written back to back, as this app used to export': ['{"imported":1}{"imported":2}', 2],
+  // The split has to respect strings, or a document containing a brace tears in half.
+  'documents holding braces and escaped quotes in their values': ['{"imported":"}{ \\" here"}\n{"imported":2}', 2],
+};
+
+// Nothing here is a run of documents, and a partial import would be worse than a refusal.
+const rejected = {
+  'content between documents': '{"imported":1} junk {"imported":2}',
+  'a truncated document': '{"imported":1',
+  'plain text': 'not json at all',
+  'unbalanced brackets': '{"imported":1}}',
+};
+
+describe('Router import', () => {
+  let request;
+  let close;
+  let client;
+
+  before(async () => {
+    client = await initializeDb();
+    const server = await createServer();
+    request = server.request;
+    close = server.close;
+  });
+
+  after(async () => {
+    await Promise.all([cleanAndCloseDb(client), close()]);
+  });
+
+  beforeEach(() => testCollection(client).deleteMany({ imported: { $exists: true } }));
+
+  describe('accepts the shapes people actually have', () => {
+    for (const [label, [body, expected]] of Object.entries(accepted)) {
+      it(`imports ${label}`, async () => {
+        const res = await importFile(request, body).expect(200);
+
+        expect(res.text).to.contain(`${expected} document(s) inserted`);
+        expect(await testCollection(client).countDocuments({ imported: { $exists: true } }))
+          .to.equal(expected);
+      });
+    }
+  });
+
+  describe('refuses what it cannot read', () => {
+    for (const [label, body] of Object.entries(rejected)) {
+      it(`rejects ${label}`, async () => {
+        await importFile(request, body).expect(400);
+
+        // A rejected file must leave nothing behind.
+        expect(await testCollection(client).countDocuments({ imported: { $exists: true } }))
+          .to.equal(0);
+      });
+    }
+  });
+
+  // The heart of the issue: whatever the export writes, the import has to read back.
+  describe('round-trips its own exports', () => {
+    for (const route of ['export', 'expArr']) {
+      it(`imports what /${route} produced`, async () => {
+        const exported = await request.get(`/db/${dbName}/${route}/${urlColName}`)
+          .expect(200).responseType('blob');
+        const body = exported.body.toString();
+
+        // Re-importing into the same collection would collide on _id, so it is dropped and
+        // Mongo assigns fresh ones. The shape under test is the file itself, not the ids.
+        const reshaped = body.replaceAll(/"_id":\{"\$oid":"[^"]+"\},/g, '')
+          .replaceAll('"testItem"', '"imported"');
+
+        const res = await importFile(request, reshaped).expect(200);
+
+        expect(res.text).to.contain('document(s) inserted');
+      });
+    }
+  });
+
+  it('separates exported documents with newlines, so the file is readable elsewhere', async () => {
+    const res = await request.get(`/db/${dbName}/export/${urlColName}`)
+      .expect(200).responseType('blob');
+    const lines = res.body.toString().split('\n').filter(Boolean);
+
+    expect(lines.length).to.be.greaterThan(1);
+
+    for (const line of lines) {
+      expect(() => JSON.parse(line), `each line should stand alone as JSON: ${line}`).to.not.throw();
+    }
+  });
+});


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1914)
- - -
<!-- Reviewable:end -->
Closes #1225, open since July 2023.

Three defects met in the same place. Between them, the only file that ever imported was a single-line array — this app’s own `Export --jsonArray` output, and nothing else. That matches every report in the thread.

Measured before the change:

| File | Before | After |
|---|---|---|
| Array on one line (`Export --jsonArray`) | 200 | 200 |
| One document per line (mongoexport) | **400** | 200 |
| A single document | **400** | 200 |
| Array pretty-printed (Compass) | **400** | 200 |
| Documents back to back (`Export Standard`) | **400** | 200 |

### Export wrote a format nothing can read

`Export Standard` emitted `{..}{..}{..}` with no separator, on one line. That is not JSON, and not the newline-delimited format `Import --mongoexport json` names, so mongoimport, Compass and this app all rejected it. Each document now ends with a newline.

### Import only ever read one shape

It parsed line by line, so anything pretty-printed failed — hence the workaround in the thread, stripping every line break by hand. It then iterated each parsed line as an array, so a plain document threw `is not iterable` and surfaced as a bare 400.

Parsing now tries the whole file first, covering an array, a single document and a pretty-printed one, then falls back to reading a run of adjacent values, covering mongoexport’s output and the glued-together files earlier versions wrote — so **exports already sitting on disk still import**, which is the literal complaint in the title. The split tracks string state, so a value containing a brace or an escaped quote does not tear in half.

Malformed input is still refused rather than partly imported: content between documents, unbalanced brackets and trailing junk each return 400 and insert nothing.

### Tests

New `test/lib/routers/importSpec.js`: every shape above, the four malformed cases, a round-trip through both export routes, and an assertion that each exported line stands alone as JSON. Suite goes 149 → 162.

Each fix was checked by reverting it alone — the old parser fails 6 of the new tests, and dropping the newline fails the export-format test.

### Separate finding, not fixed here

`ALLOWED_MIME_TYPES` accepts `text/csv`, but there is no CSV parsing, so a CSV passes the type check and then fails as `Bad file content`. Either the importer should read CSV or the type should be dropped; worth its own issue.