### PR TITLE
fix: stop rejecting uploads over a type the client chose

### DIFF
--- a/lib/routes/collection.js
+++ b/lib/routes/collection.js
@@ -7,9 +7,17 @@ import csv from '../csv.js';
 
 const { EJSON } = BSON;
 
-const ALLOWED_MIME_TYPES = new Set([
+/**
+ * A type attached to an upload is whatever the browser decided to send, so it is a hint rather
+ * than a control: any client can set it to anything, and what actually decides the outcome is
+ * whether the content parses. Gating on an allow-list only ever turned away real files — a
+ * .json offered as text/plain or application/octet-stream, which several browsers do send.
+ * These are named only so a CSV can be answered with something better than a parse failure.
+ */
+const CSV_MIME_TYPES = new Set([
   'text/csv',
-  'application/json',
+  'application/csv',
+  'text/comma-separated-values',
 ]);
 
 /**
@@ -757,11 +765,24 @@ const routes = function (config) {
 
     const files = Object.values(req.files);
 
-    const areInvalidFiles = files.some((file) => !ALLOWED_MIME_TYPES.has(file.mimetype)
-      || !file.data
-      || !file.data.toString);
-    if (areInvalidFiles) {
+    const unreadableFiles = files.some((file) => !file.data || !file.data.toString);
+
+    if (unreadableFiles) {
       return res.status(400).send('Bad file');
+    }
+
+    // CSV goes out but cannot come back: the export renders ObjectIds as the text
+    // ObjectId("..."), flattens nested documents into dotted columns and leaves every value a
+    // string, so reading one back would quietly build a collection that no longer matches what
+    // was exported. Refusing it by name beats letting it fail later as unparseable JSON.
+    const csvFile = files.find((file) => CSV_MIME_TYPES.has(file.mimetype)
+      || file.name?.toLowerCase().endsWith('.csv'));
+
+    if (csvFile) {
+      return res.status(400).send(
+        'CSV import is not supported, because the CSV export cannot be read back without losing '
+        + 'types. Export the collection as JSON and import that instead.',
+      );
     }
 
     const docs = [];
@@ -776,7 +797,13 @@ const routes = function (config) {
         }
       } catch (error) {
         console.error(error);
-        return res.status(400).send('Bad file content');
+
+        // Name the shapes that do work. The old message said only that something was wrong,
+        // which is why the issue thread filled up with people guessing at the format.
+        return res.status(400).send(
+          `Bad file content: ${error.message}. Expected JSON documents, as an array, one per `
+          + 'line, or a single document.',
+        );
       }
     }
     await req.collection.insertMany(docs).then((stats) => {

--- a/test/lib/routers/importSpec.js
+++ b/test/lib/routers/importSpec.js
@@ -67,9 +67,56 @@ describe('Router import', () => {
   describe('refuses what it cannot read', () => {
     for (const [label, body] of Object.entries(rejected)) {
       it(`rejects ${label}`, async () => {
-        await importFile(request, body).expect(400);
+        const res = await importFile(request, body).expect(400);
+
+        // The old message named nothing, which is why the issue thread filled with guesses.
+        expect(res.text).to.contain('Expected JSON documents');
 
         // A rejected file must leave nothing behind.
+        expect(await testCollection(client).countDocuments({ imported: { $exists: true } }))
+          .to.equal(0);
+      });
+    }
+  });
+
+  // The type on an upload is set by the browser and can be anything a client cares to send, so
+  // it never decided whether a file was safe — only whether a real one got turned away. Several
+  // browsers label a .json as text/plain or application/octet-stream, and those uploads used to
+  // come back as a bare 'Bad file'.
+  describe('does not turn away files over the type the browser attached', () => {
+    for (const mimetype of [
+      'application/json',
+      'text/json',
+      'text/plain',
+      'application/octet-stream',
+      'application/x-json',
+    ]) {
+      it(`imports a JSON file sent as ${mimetype}`, async () => {
+        await request.post(`/db/${dbName}/import/${urlColName}`)
+          .attach('file', Buffer.from('{"imported":1}'), { filename: 'import.json', contentType: mimetype })
+          .expect(200);
+
+        expect(await testCollection(client).countDocuments({ imported: { $exists: true } }))
+          .to.equal(1);
+      });
+    }
+  });
+
+  // CSV is offered on the way out, so people reasonably try to bring one back. It cannot work:
+  // the export renders ObjectIds as text, flattens nested documents into dotted columns and
+  // leaves every value a string. Better to say so than to fail as unparseable JSON.
+  describe('explains that CSV cannot be imported', () => {
+    for (const [label, filename, mimetype] of [
+      ['by its type', 'export.csv', 'text/csv'],
+      ['by its extension', 'export.csv', 'text/plain'],
+    ]) {
+      it(`recognises a CSV ${label}`, async () => {
+        const res = await request.post(`/db/${dbName}/import/${urlColName}`)
+          .attach('file', Buffer.from('_id,name\n1,alice'), { filename, contentType: mimetype })
+          .expect(400);
+
+        expect(res.text).to.contain('CSV import is not supported');
+        expect(res.text, 'should say what to do instead').to.contain('JSON');
         expect(await testCollection(client).countDocuments({ imported: { $exists: true } }))
           .to.equal(0);
       });


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1915)
- - -
<!-- Reviewable:end -->
Follow-up to #1914, from a finding noted there. **Based on `fix/1225-import-own-export`, so please merge #1914 first** — GitHub will retarget this to `master` automatically.

### The type on an upload was never a control

The importer allowed only `application/json` and `text/csv`. That type is set by the browser and can be anything a client cares to send, so it never decided whether a file was safe — only whether a real one got turned away. Measured against the endpoint:

| Uploaded as | Before | After |
|---|---|---|
| `application/json` | 200 | 200 |
| `text/json` | **400 Bad file** | 200 |
| `text/plain` | **400 Bad file** | 200 |
| `application/octet-stream` | **400 Bad file** | 200 |
| `application/x-json` | **400 Bad file** | 200 |

Several browsers label a `.json` as `text/plain` or `application/octet-stream`, so those users got a bare `Bad file` with nothing to act on. This is the report from @vorou in #1225 that never got explained. What actually validates an import is whether the content parses, and that runs either way.

### CSV was advertised and then failed confusingly

`text/csv` passed the gate and died as unparseable JSON, because no CSV parsing exists. It cannot be added without losing data — the CSV export renders ObjectIds as the text `ObjectId("...")`, flattens nested documents into dotted columns via `flat`, and leaves every value a string, so re-importing would quietly build a collection that no longer matches what was exported.

So a CSV is now refused by name, recognised by type or `.csv` extension, with a message saying to export as JSON instead. Pretending to support it would be worse than saying no.

### Error messages

Parse failures now name the shapes that work instead of only reporting that something was wrong — the thing that had people in #1225 guessing at the format for two years.

### Tests

Suite 162 → 169. Reverting the allow-list fails 5 of the new tests.

### Note for reviewers

This widens what the endpoint accepts, so it deserves a security read. My reasoning is that the multipart content type is attacker-controlled and therefore never provided a boundary; the real ones are unchanged — the upload size limit in `middleware.js`, CSRF, and the read-only guard. If you disagree, I would rather hear it than have this merged on my say-so.