### PR TITLE
build: stop running dependency install scripts by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,12 @@ compressionLevel: mixed
 
 enableGlobalCache: true
 
+# Install scripts are how a poisoned package gets to run code on a developer's machine, and
+# they run before anyone has a chance to look at what was downloaded. Nothing here needs them
+# except the two packages that fetch a binary, which are opted back in through
+# dependenciesMeta in package.json.
+enableScripts: false
+
 nodeLinker: node-modules
 
 plugins:

--- a/package.json
+++ b/package.json
@@ -103,6 +103,14 @@
       "optional": true
     }
   },
+  "dependenciesMeta": {
+    "cypress": {
+      "built": true
+    },
+    "mongodb-memory-server": {
+      "built": true
+    }
+  },
   "resolutions": {
     "csurf/cookie": "^0.7.2",
     "@cypress/request/qs": "^6.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6809,6 +6809,11 @@ __metadata:
     webpack-cli: "npm:^7.2.2"
   peerDependencies:
     express-openid-connect: "*"
+  dependenciesMeta:
+    cypress:
+      built: true
+    mongodb-memory-server:
+      built: true
   peerDependenciesMeta:
     express-openid-connect:
       optional: true


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1916)
- - -
<!-- Reviewable:end -->
Install scripts are how a poisoned package gets to run code on a developer's machine, and they run before anyone has had a chance to look at what was downloaded. The npm worm reported on 2026-08-04 reached its payload exactly that way, through a `preinstall` script added to versions of packages that had never carried one — `keyv` and `flat-cache` among them.

**This repository was not affected.** Neither package is a direct dependency, and the pinned versions are far below the poisoned ones (`keyv` 4.5.4 vs 6.0.0, `flat-cache` 4.0.1 vs 6.1.23; `cache-manager` is not in the tree at all). I checked the tree for the campaign's indicators — `preinstall` scripts, `setup.mjs`, `Math_Symbol.js` — and found none. This PR is hardening, not remediation.

## The change

```yaml
# .yarnrc.yml
enableScripts: false
```

```jsonc
// package.json
"dependenciesMeta": {
  "cypress": { "built": true },
  "mongodb-memory-server": { "built": true }
}
```

Only those two packages need an install script, and only to fetch a binary. Everything else is now inert on install.

Of the other two packages that turned up in a lifecycle-script scan: `is-installed-globally` declares none, and the `postinstall: lerna bootstrap` belongs to `resolve/test/resolver/multirepo`, a test fixture nested inside `resolve` that is never installed as a dependency.

## What it does not touch

The setting applies to dependencies, not to this project's own scripts. `yarn build`, `yarn mocha` and `yarn lint` are unaffected — all three verified green. `publish.yml` runs `npm publish`, which does not consult a Yarn setting.

## Verification

From a wiped `node_modules`, a clean install builds exactly the two exempted packages and nothing else:

```
YN0007: │ cypress@npm:15.19.0 must be built because it never has been before or the last one failed
YN0007: │ mongodb-memory-server@npm:11.2.0 must be built because it never has been before or the last one failed
```

`yarn install --immutable` passes, so the lockfile is correct for CI.

To confirm the block is real rather than there being nothing left to run, I installed a package carrying a `preinstall` that writes a file, twice, with the same Yarn and only the flag changed:

| `enableScripts` | `preinstall` ran? |
| --- | --- |
| `false` | no |
| `true` | yes |

The package reached `node_modules` in both cases, so the negative is not a failed install in disguise.

## Worth being clear about

**Today this blocks zero scripts.** The only two that exist are both exempted. The value is entirely prospective: it is a ratchet, so that a dependency *gaining* an install script — precisely what the worm did — is inert instead of executed, and adding one back becomes a deliberate, reviewable edit to `dependenciesMeta`.

Milestone 1.1.