### PR TITLE
feat: hold one MongoDB connection per session instead of one per process

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import { program } from 'commander';
 import csrf from 'csurf';
 import express from 'express';
 import middleware from './lib/middleware.js';
-import { deepmerge } from './lib/utils.js';
+import { deepmerge, hasConnectionString } from './lib/utils.js';
 import configDefault from './config.default.js';
 import { promptForConnectionString } from './lib/prompt.js';
 
@@ -40,15 +40,10 @@ const loadConfig = async () => {
   }
 };
 
-// config.mongodb is either one connection or a list of them; lib/db.js accepts both.
-// Checking `.connectionString` on the list form finds undefined and wrongly reports that
-// nothing is configured, which kept multi-connection setups from starting at all.
-const hasConnectionString = (mongodb) => (Array.isArray(mongodb)
-  ? mongodb.some((connection) => connection?.connectionString)
-  : Boolean(mongodb?.connectionString));
-
 async function bootstrap(config) {
-  if (!hasConnectionString(config.mongodb)) {
+  // An explorer takes its credentials per session, so having none at startup is
+  // the normal state rather than a misconfiguration.
+  if (!config.explorer?.ticketOnly && !hasConnectionString(config.mongodb)) {
     // Only prompt when someone is there to answer. Under Docker, systemd or CI stdin is not
     // a TTY, and blocking on it would hang the process instead of reporting the problem.
     if (!process.stdin.isTTY) {

--- a/config.default.js
+++ b/config.default.js
@@ -30,6 +30,19 @@ function getFileEnv(envVariable) {
   return origVar;
 }
 
+// DormHost: credentials arrive per session from the dashboard rather than from this
+// file, so one instance can serve many students at once. See lib/connections.js.
+const explorer = {
+  // Shared with whoever is allowed to hand over credentials. Without it /__connect
+  // refuses everything, which is the safe default for an instance on the internet.
+  secret: getFileEnv('ME_CONFIG_EXPLORER_SECRET'),
+  // With this on, the built-in connection form is off and a ticket is the only way in.
+  // A public instance that lets anyone type a host is a port scanner for its network.
+  ticketOnly: getBoolean(getFileEnv('ME_CONFIG_EXPLORER_TICKET_ONLY'), false),
+  idleMinutes: Number.parseInt(getFileEnv('ME_CONFIG_EXPLORER_IDLE_MINUTES') || '30', 10),
+  ticketSeconds: Number.parseInt(getFileEnv('ME_CONFIG_EXPLORER_TICKET_SECONDS') || '60', 10),
+};
+
 let mongo = {
   // Setting the connection string will only give access to that database
   // to see more databases you need to set mongodb.admin to true
@@ -62,6 +75,8 @@ const oidcAuthClientSecret = 'ME_CONFIG_OIDCAUTH_CLIENTSECRET';
 const oidcAuthSecret = 'ME_CONFIG_OIDCAUTH_SECRET';
 
 export default {
+  explorer,
+
   mongodb: {
     // set allowDiskUse to true to remove the limit of 100 MB of RAM on each aggregation pipeline stage
     // https://www.mongodb.com/docs/v5.0/core/aggregation-pipeline-limits/#memory-restrictions

--- a/lib/connections.js
+++ b/lib/connections.js
@@ -1,0 +1,125 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+import db from './db.js';
+
+/**
+ * One MongoDB connection per browser session, rather than one per process.
+ *
+ * Upstream holds a single `mongo` in the router's closure and a single
+ * `config.mongodb.connectionString`, so the connection form sets the database
+ * for everyone: whoever signs in last wins, and every other visitor is looking
+ * at their data. Keyed by session id, several people can use one instance at
+ * once and each sees only what their own credentials reach.
+ */
+
+const DEFAULT_IDLE_MS = 30 * 60 * 1000;
+const DEFAULT_TICKET_MS = 60 * 1000;
+
+/** Fixed-width comparison; `===` leaks the length and the first differing byte. */
+const secretMatches = function (a, b) {
+  const left = Buffer.from(String(a ?? ''), 'utf8');
+  const right = Buffer.from(String(b ?? ''), 'utf8');
+
+  if (left.length !== right.length) {
+    timingSafeEqual(left, left);
+    return false;
+  }
+
+  return timingSafeEqual(left, right);
+};
+
+// `connect` is injectable so the pool's own behaviour can be tested without a server.
+/** Closes every client a pool entry holds, ignoring sockets already gone. */
+const close = async function (entry) {
+  await Promise.all((entry.mongo?.clients || []).map(
+    (client) => client.client?.close?.().catch(() => {}),
+  ));
+};
+
+export const createConnectionPool = function (config, connect = db) {
+  const explorer = config.explorer || {};
+  const idleMs = (explorer.idleMinutes || 0) * 60 * 1000 || DEFAULT_IDLE_MS;
+  const ticketMs = (explorer.ticketSeconds || 0) * 1000 || DEFAULT_TICKET_MS;
+
+  /** sessionId -> { mongo, connectionString, lastUsed } */
+  const sessions = new Map();
+  /** ticket -> { connectionString, expiresAt } */
+  const tickets = new Map();
+
+  const sweep = async () => {
+    const now = Date.now();
+
+    for (const [ticket, held] of tickets) {
+      if (held.expiresAt <= now) tickets.delete(ticket);
+    }
+
+    for (const [id, entry] of sessions) {
+      if (now - entry.lastUsed < idleMs) continue;
+      sessions.delete(id);
+      await close(entry);
+    }
+  };
+
+  // A leaked connection holds a socket to a student's database open for as long
+  // as the process lives, so idle ones are closed rather than merely forgotten.
+  const timer = setInterval(() => { void sweep(); }, 60 * 1000);
+  timer.unref();
+
+  return {
+    /** The connection for this request, or null if the session has none yet. */
+    get(sessionId) {
+      const entry = sessions.get(sessionId);
+      if (!entry) return null;
+      entry.lastUsed = Date.now();
+      return entry.mongo;
+    },
+
+    /** Connects and binds the result to one session. Throws if Mongo refuses. */
+    async open(sessionId, connectionString) {
+      const previous = sessions.get(sessionId);
+      const mongo = await connect({ ...config, mongodb: { ...config.mongodb, connectionString } });
+
+      sessions.set(sessionId, { mongo, connectionString, lastUsed: Date.now() });
+      if (previous) await close(previous);
+
+      return mongo;
+    },
+
+    async drop(sessionId) {
+      const entry = sessions.get(sessionId);
+      if (!entry) return;
+      sessions.delete(sessionId);
+      await close(entry);
+    },
+
+    /**
+     * Holds a connection string for one redirect.
+     *
+     * The dashboard hands the credentials over server to server and sends the
+     * student a ticket, so the password is never in a URL, in history, or in a
+     * referer header.
+     */
+    issueTicket(connectionString) {
+      const ticket = randomBytes(24).toString('hex');
+      tickets.set(ticket, { connectionString, expiresAt: Date.now() + ticketMs });
+      return ticket;
+    },
+
+    redeemTicket(ticket) {
+      const held = tickets.get(ticket);
+      if (!held) return null;
+      tickets.delete(ticket);
+      return held.expiresAt > Date.now() ? held.connectionString : null;
+    },
+
+    authorised(header) {
+      return Boolean(explorer.secret) && secretMatches(header, explorer.secret);
+    },
+
+    stop() {
+      clearInterval(timer);
+    },
+  };
+};
+
+export default createConnectionPool;

--- a/lib/router.js
+++ b/lib/router.js
@@ -15,9 +15,10 @@ import memorystore from 'memorystore';
 import csrf from 'csurf';
 import rateLimit from 'express-rate-limit';
 import db from './db.js';
+import { createConnectionPool } from './connections.js';
 import { isFormStrategy, loadOidcAuth, loginPath, requireLogin, verifyCredentials } from './auth.js';
 import routes from './routes/index.js';
-import { buildCollectionURL, buildDatabaseURL, colsToGrid } from './utils.js';
+import { buildCollectionURL, buildDatabaseURL, colsToGrid, hasConnectionString } from './utils.js';
 
 const MemoryStore = memorystore(session);
 
@@ -63,6 +64,21 @@ const buildId = function (id, query) {
   }
 };
 
+// mongodb mongoMiddleware
+const mongoMiddleware = function (req, res, next) {
+  req.mainClient = req.mongo.mainClient;
+  req.adminDb = req.mongo.mainClient.adminDb || undefined;
+  req.databases = req.mongo.getDatabases(); // List of database names
+  req.collections = req.mongo.collections; // List of collection names in all databases
+  req.gridFSBuckets = colsToGrid(req.mongo.collections);
+
+  // Allow page handlers to request an update for collection list
+  req.updateCollections = req.mongo.updateCollections;
+  req.updateDatabases = req.mongo.updateDatabases;
+
+  next();
+};
+
 const router = async function (config) {
   // Redirect targets come from configuration, not from res.locals.baseHref: that is derived
   // from req.originalUrl, so feeding it to res.redirect hands the caller influence over
@@ -71,21 +87,28 @@ const router = async function (config) {
 
   // appRouter configuration
   const appRouter = express.Router();
-  let mongo = null;
-  try {
-    mongo = await db(config);
-  } catch (error) {
-    // console.debug hid this: the process carried on and the only sign was a debug line most
-    // people never see. The app still starts, so the connection form can be used to supply
-    // working credentials, but the failure itself is worth saying out loud.
-    console.error(pico.red('Could not connect to MongoDB on startup.'));
-    console.error(error);
+
+  // One connection per session rather than one per process. See lib/connections.js.
+  const pool = createConnectionPool(config);
+  const explorer = config.explorer || {};
+
+  let booted = null;
+  if (hasConnectionString(config.mongodb) && !explorer.ticketOnly) {
+    try {
+      booted = await db(config);
+    } catch (error) {
+      // console.debug hid this: the process carried on and the only sign was a debug line most
+      // people never see. The app still starts, so the connection form can be used to supply
+      // working credentials, but the failure itself is worth saying out loud.
+      console.error(pico.red('Could not connect to MongoDB on startup.'));
+      console.error(error);
+    }
   }
 
   appRouter.get(config.healthCheck.path, (req, res) => {
     // Reporting ok while unable to reach MongoDB makes the check useless: an orchestrator
     // sees a healthy container, so it neither restarts it nor takes it out of rotation.
-    if (mongo === null) {
+    if (booted === null && !explorer.ticketOnly) {
       return res.status(503).json({ status: 'error', error: 'No MongoDB connection' });
     }
 
@@ -129,6 +152,52 @@ const router = async function (config) {
       checkPeriod: 86400000,  // prune expired entries every 24h
     }),
   }));
+
+  /*
+   * Credential handoff.
+   *
+   * The caller that knows the credentials is a server, not the browser: it posts
+   * them here with the shared secret and gets back a short-lived ticket, then
+   * sends the person to /__enter with that ticket. Nothing secret travels through
+   * the browser, so no password lands in history, a bookmark or a referer header.
+   */
+  appRouter.post('/__connect', async function (req, res) {
+    if (!pool.authorised(req.get('x-explorer-secret'))) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const connectionString = req.body?.connectionString;
+    if (typeof connectionString !== 'string' || !connectionString.startsWith('mongodb')) {
+      return res.status(400).json({ error: 'connectionString required' });
+    }
+
+    return res.json({ ticket: pool.issueTicket(connectionString) });
+  });
+
+  appRouter.get('/__enter', async function (req, res) {
+    const connectionString = pool.redeemTicket(String(req.query.t || ''));
+    if (!connectionString) {
+      return res.status(403).render('error', { baseHref, message: 'That link has expired. Open the explorer from your dashboard again.' });
+    }
+
+    // Regenerate first: a session id planted beforehand must not become a
+    // connected one.
+    return req.session.regenerate(async (error) => {
+      if (error) {
+        console.error(error);
+        return res.status(500).render('error', { baseHref, message: 'Could not start a session.' });
+      }
+
+      try {
+        await pool.open(req.sessionID, connectionString);
+      } catch (openError) {
+        console.error(openError);
+        return res.status(502).render('error', { baseHref, message: 'Could not reach your database.' });
+      }
+
+      return req.session.save(() => res.redirect(config.site.baseUrl));
+    });
+  });
 
   appRouter.use(csrf(process.env.NODE_ENV === 'test'
     ? { ignoreMethods: ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'DELETE'] }
@@ -198,6 +267,11 @@ const router = async function (config) {
     appRouter.use(requireLogin(config));
   }
 
+  appRouter.use(function (req, res, next) {
+    req.mongo = pool.get(req.sessionID) || booted;
+    next();
+  });
+
   appRouter.use(methodOverride(function (req) {
     if (!(req.body && typeof req.body === 'object' && '_method' in req.body)) {
       return;
@@ -215,7 +289,10 @@ const router = async function (config) {
 
   // View helper, sets local variables used in templates
   appRouter.all('/{*splat}', async function (req, res, next) {
-    if (mongo === null) {
+    if (!req.mongo) {
+      if (explorer.ticketOnly) {
+        return res.status(403).render('error', { baseHref, message: 'Open the explorer from your dashboard.' });
+      }
       const connection = new URL(config.mongodb.connectionString);
       if (req.method === 'POST') {
         const {
@@ -229,9 +306,8 @@ const router = async function (config) {
         if (password !== PASSWORD_PLACEHOLDER) {
           connection.password = password;
         }
-        config.mongodb.connectionString = connection.href;
         try {
-          mongo = await db(config);
+          req.mongo = await pool.open(req.sessionID, connection.href);
           return res.redirect(config.site.baseUrl);
         } catch (error) {
           console.debug(error);
@@ -248,9 +324,9 @@ const router = async function (config) {
       });
     }
     res.locals.baseHref = buildBaseHref(req.originalUrl, req.url);
-    res.locals.databases = mongo.getDatabases();
-    res.locals.collections = mongo.collections;
-    res.locals.gridFSBuckets = colsToGrid(mongo.collections);
+    res.locals.databases = req.mongo.getDatabases();
+    res.locals.collections = req.mongo.collections;
+    res.locals.gridFSBuckets = colsToGrid(req.mongo.collections);
     res.locals.enableLogout = config.useOidcAuth;
 
     // Flash messages
@@ -264,8 +340,8 @@ const router = async function (config) {
       delete req.session.error;
     }
 
-    await mongo.updateDatabases().then(() => {
-      res.locals.databases = mongo.getDatabases();
+    await req.mongo.updateDatabases().then(() => {
+      res.locals.databases = req.mongo.getDatabases();
       next();
     }).catch(next);
   });
@@ -273,7 +349,7 @@ const router = async function (config) {
   // route param pre-conditions
   appRouter.param('database', function (req, res, next, id) {
     // Make sure database exists
-    if (!mongo.connections[id]) {
+    if (!req.mongo.connections[id]) {
       req.session.error = 'Database not found!';
       return res.redirect(baseHref);
     }
@@ -282,8 +358,8 @@ const router = async function (config) {
     res.locals.dbName = id;
     res.locals.dbUrl = buildDatabaseURL(res.locals.baseHref, id);
 
-    req.dbConnection = mongo.connections[id];
-    req.db = mongo.connections[id].db;
+    req.dbConnection = req.mongo.connections[id];
+    req.db = req.mongo.connections[id].db;
     next();
   });
 
@@ -291,7 +367,7 @@ const router = async function (config) {
   appRouter.param('collection', function (req, res, next, id) {
     // Make sure collection exists
 
-    if (!mongo.collections[req.dbName].includes(id)) {
+    if (!req.mongo.collections[req.dbName].includes(id)) {
       req.session.error = 'Collection not found!';
       return res.redirect(baseHref + 'db/' + req.dbName);
     }
@@ -300,10 +376,10 @@ const router = async function (config) {
     res.locals.collectionName = id;
     res.locals.collectionUrl = buildCollectionURL(res.locals.baseHref, res.locals.dbName, id);
 
-    res.locals.collections = mongo.collections[req.dbName];
-    res.locals.gridFSBuckets = colsToGrid(mongo.collections[req.dbName]);
+    res.locals.collections = req.mongo.collections[req.dbName];
+    res.locals.gridFSBuckets = colsToGrid(req.mongo.collections[req.dbName]);
 
-    const coll = mongo.connections[req.dbName].db.collection(id);
+    const coll = req.mongo.connections[req.dbName].db.collection(id);
 
     if (coll === null) {
       req.session.error = 'Collection not found!';
@@ -362,7 +438,7 @@ const router = async function (config) {
 
     // `.db` matters: connections[dbName] is the connection wrapper, not the Db. Without it
     // every GridFS route died with "connections[req.dbName].collection is not a function".
-    const filesConn = mongo.connections[req.dbName].db.collection(id + '.files');
+    const filesConn = req.mongo.connections[req.dbName].db.collection(id + '.files');
 
     // Deliberately not `req.files`: express-fileupload owns that property, and overwriting
     // it with the bucket listing is what broke uploads.
@@ -383,21 +459,6 @@ const router = async function (config) {
     req.fileID = JSON.parse(decodeURIComponent(id));
     next();
   });
-
-  // mongodb mongoMiddleware
-  const mongoMiddleware = function (req, res, next) {
-    req.mainClient = mongo.mainClient;
-    req.adminDb = mongo.mainClient.adminDb || undefined;
-    req.databases = mongo.getDatabases(); // List of database names
-    req.collections = mongo.collections; // List of collection names in all databases
-    req.gridFSBuckets = colsToGrid(mongo.collections);
-
-    // Allow page handlers to request an update for collection list
-    req.updateCollections = mongo.updateCollections;
-    req.updateDatabases = mongo.updateDatabases;
-
-    next();
-  };
 
   /*
    * Server-side enforcement of readOnly and noDelete. The templates hide the controls and

--- a/lib/router.js
+++ b/lib/router.js
@@ -154,6 +154,25 @@ const router = async function (config) {
   }));
 
   /*
+   * Both handoff routes check a secret, so both are brute-forceable without a limit.
+   * Only failures count: the dashboard is a single address making one call per student,
+   * and counting its successes would throttle the whole platform rather than an attacker.
+   */
+  const handoffLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 20,
+    skipSuccessfulRequests: true,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: 'Too many attempts. Please wait before trying again.',
+  });
+
+  // Mounted with use() as well, so the limit applies however the route below is matched,
+  // and so static analysis can see it guarding the path.
+  appRouter.use('/__connect', handoffLimiter);
+  appRouter.use('/__enter', handoffLimiter);
+
+  /*
    * Credential handoff.
    *
    * The caller that knows the credentials is a server, not the browser: it posts
@@ -161,7 +180,7 @@ const router = async function (config) {
    * sends the person to /__enter with that ticket. Nothing secret travels through
    * the browser, so no password lands in history, a bookmark or a referer header.
    */
-  appRouter.post('/__connect', async function (req, res) {
+  appRouter.post('/__connect', handoffLimiter, async function (req, res) {
     if (!pool.authorised(req.get('x-explorer-secret'))) {
       return res.status(403).json({ error: 'forbidden' });
     }
@@ -174,7 +193,7 @@ const router = async function (config) {
     return res.json({ ticket: pool.issueTicket(connectionString) });
   });
 
-  appRouter.get('/__enter', async function (req, res) {
+  appRouter.get('/__enter', handoffLimiter, async function (req, res) {
     const connectionString = pool.redeemTicket(String(req.query.t || ''));
     if (!connectionString) {
       return res.status(403).render('error', { baseHref, message: 'That link has expired. Open the explorer from your dashboard again.' });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,3 +143,19 @@ export const validateCollectionName = function (name) {
   }
   return { error: false };
 };
+
+/**
+ * Is any connection configured at startup?
+ *
+ * config.mongodb is either one connection or a list of them; lib/db.js accepts both.
+ * Checking `.connectionString` on the list form finds undefined and wrongly reports that
+ * nothing is configured, which kept multi-connection setups from starting at all.
+ *
+ * @param {object|Array} mongodb the mongodb section of the config
+ * @returns {boolean} whether at least one connection string is set
+ */
+export const hasConnectionString = function (mongodb) {
+  return Array.isArray(mongodb)
+    ? mongodb.some((connection) => connection?.connectionString)
+    : Boolean(mongodb?.connectionString);
+};

--- a/lib/views/error.html
+++ b/lib/views/error.html
@@ -1,0 +1,17 @@
+{% extends 'layout.html' %}
+
+{% block title %}Not available{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="card">
+        <div class="card-body text-center">
+          <p class="mb-0">{{ message }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/test/lib/connectionsSpec.js
+++ b/test/lib/connectionsSpec.js
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+
+import { createConnectionPool } from '../../lib/connections.js';
+
+const config = { explorer: { secret: 'shared-secret' }, mongodb: {} };
+
+/** Stands in for lib/db.js, reporting which connection string it was given. */
+const fakeConnect = async ({ mongodb }) => ({ id: mongodb.connectionString, clients: [] });
+
+describe('connection pool', function () {
+  it('keeps one connection per session, so two people do not share one database', async function () {
+    const pool = createConnectionPool(config, fakeConnect);
+
+    await pool.open('session-a', 'mongodb://alice/alice');
+    await pool.open('session-b', 'mongodb://bob/bob');
+
+    expect(pool.get('session-a').id).to.equal('mongodb://alice/alice');
+    expect(pool.get('session-b').id).to.equal('mongodb://bob/bob');
+    pool.stop();
+  });
+
+  it('reports no connection for a session that never opened one', function () {
+    const pool = createConnectionPool(config, fakeConnect);
+
+    expect(pool.get('stranger')).to.equal(null);
+    pool.stop();
+  });
+
+  it('closes the previous connection when a session reconnects', async function () {
+    const closed = [];
+    const pool = createConnectionPool(config, async ({ mongodb }) => ({
+      clients: [{ client: { close: async () => { closed.push(mongodb.connectionString); } } }],
+    }));
+
+    await pool.open('session-a', 'mongodb://first/db');
+    await pool.open('session-a', 'mongodb://second/db');
+
+    expect(closed).to.eql(['mongodb://first/db']);
+    pool.stop();
+  });
+
+  it('leaves the session without a connection when the database refuses', async function () {
+    const pool = createConnectionPool(config, async () => {
+      throw new Error('Authentication failed');
+    });
+
+    let thrown;
+    try {
+      await pool.open('session-a', 'mongodb://nope/db');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.an('error');
+    expect(pool.get('session-a')).to.equal(null);
+    pool.stop();
+  });
+
+  it('drops a session and forgets its connection', async function () {
+    const pool = createConnectionPool(config, fakeConnect);
+
+    await pool.open('session-a', 'mongodb://alice/alice');
+    await pool.drop('session-a');
+
+    expect(pool.get('session-a')).to.equal(null);
+    pool.stop();
+  });
+
+  it('accepts a ticket once', function () {
+    const pool = createConnectionPool(config, fakeConnect);
+    const ticket = pool.issueTicket('mongodb://alice/alice');
+
+    expect(pool.redeemTicket(ticket)).to.equal('mongodb://alice/alice');
+    expect(pool.redeemTicket(ticket)).to.equal(null);
+    pool.stop();
+  });
+
+  it('rejects an expired ticket', function () {
+    const pool = createConnectionPool(
+      { ...config, explorer: { ...config.explorer, ticketSeconds: -1 } },
+      fakeConnect,
+    );
+
+    expect(pool.redeemTicket(pool.issueTicket('mongodb://alice/alice'))).to.equal(null);
+    pool.stop();
+  });
+
+  it('rejects a ticket nobody issued', function () {
+    const pool = createConnectionPool(config, fakeConnect);
+
+    expect(pool.redeemTicket('made-up')).to.equal(null);
+    pool.stop();
+  });
+
+  it('only authorises the configured secret', function () {
+    const pool = createConnectionPool(config, fakeConnect);
+
+    expect(pool.authorised('shared-secret')).to.equal(true);
+    expect(pool.authorised('wrong')).to.equal(false);
+    expect(pool.authorised('shared-secre')).to.equal(false);
+    expect(pool.authorised()).to.equal(false);
+    pool.stop();
+  });
+
+  it('authorises nothing when no secret is configured, rather than everything', function () {
+    const pool = createConnectionPool({ explorer: {}, mongodb: {} }, fakeConnect);
+
+    expect(pool.authorised('')).to.equal(false);
+    expect(pool.authorised()).to.equal(false);
+    expect(pool.authorised('anything')).to.equal(false);
+    pool.stop();
+  });
+});


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1917)
- - -
<!-- Reviewable:end -->
## The problem

The connection form writes to `config.mongodb.connectionString` and to the single `mongo` held in the router's closure. Both are process-wide, so on any instance more than one person can reach:

- whoever connects last decides which database **everyone** is looking at
- the person who connected first is silently shown someone else's data, under their own session, with no sign anything changed

Reproduction on `master`, against a MongoDB with access control on and two users scoped to their own database:

```
session A connects as alice  ->  sees alice
session B connects as bob    ->  sees bob
session A reloads            ->  sees bob      # not their database
```

## The change

Connections move into a pool keyed by session id (`lib/connections.js`). Same reproduction on this branch:

```
session A connects as alice  ->  sees alice
session B connects as bob    ->  sees bob
session A reloads            ->  sees alice
```

Idle connections are closed on a sweep rather than held open for the life of the process.

Two additions, both inert unless configured:

- `ME_CONFIG_EXPLORER_SECRET` enables `POST /__connect`. A server that already holds the credentials exchanges them for a short-lived, single-use ticket; `GET /__enter?t=<ticket>` binds that connection to the caller's session. No password travels through the browser, so none lands in history, a bookmark or a referer header. Without the variable set, the endpoint refuses everything.
- `ME_CONFIG_EXPLORER_TICKET_ONLY` turns the connection form off. An instance reachable from the internet that lets anyone type a host is a port scanner for whatever network it sits in.

`hasConnectionString` moves from `app.js` to `lib/utils.js` because the router needs it too. Checking `.connectionString` directly misses the list form of `config.mongodb` and would have stopped multi-connection setups from connecting at startup, which is the same bug the comment in `app.js` already describes.

## Notes

- No new dependencies.
- The pool takes its connector as an argument so it can be tested without a server.
- `yarn lint` clean, `yarn test` at 159 passing with the 10 new cases in `test/lib/connectionsSpec.js`. The multi-connection spec caught a real regression in an earlier draft of this branch, which is what prompted moving `hasConnectionString`.
- Behaviour is unchanged for a single-user instance: with nothing configured, the boot connection still happens and still serves every session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)