### PR TITLE
Bug/1640  Fix: editing/deleting documents with $-prefixed field names fails

### DIFF
--- a/lib/routes/document.js
+++ b/lib/routes/document.js
@@ -83,7 +83,7 @@ const routes = function (config) {
 
     docBSON._id = req.document._id;
 
-    await req.collection.replaceOne(req.document, docBSON).then(() => {
+    await req.collection.replaceOne({ _id: req.document._id }, docBSON).then(() => {
       req.session.success = 'Document updated!';
 
       if (config.options.persistEditMode === true) {
@@ -107,7 +107,7 @@ const routes = function (config) {
     const jsonQuery       = req.query.query       || '';
     const jsonProjection  = req.query.projection  || '';
 
-    await req.collection.deleteOne(req.document).then(() => {
+    await req.collection.deleteOne({ _id: req.document._id }).then(() => {
       req.session.success = 'Document deleted! _id: ' + filters.stringDocIDs(req.document._id);
       res.redirect(
         buildCollectionURL(res.locals.baseHref, req.dbName, req.collectionName)

--- a/test/lib/routers/documentSpec.js
+++ b/test/lib/routers/documentSpec.js
@@ -110,6 +110,30 @@ describe('Router document', () => {
   it('DEL /db/<dbName>/<collection>/<document> should delete the document');
   it('PUT /db/<dbName>/<collection>/<document> should update the document');
 
+
+
+
+
+   describe('Document with a $-prefixed field name', () => {
+    it('should update a document that has a $-prefixed field', async () => {
+      const _id = new ObjectId();
+      await testCollection(db).insertOne({ _id, weird: { $concatArrays: ['$a', ['b']] } });
+
+      await request.put(getDocumentUrl(dbName, urlColName, _id.toString()))
+        .send({ document: `{_id:ObjectId("${_id}"),testValue:"fixed"}` })
+        .expect(302);
+
+      const result = await testCollection(db).findOne({ _id });
+      expect(result.testValue).to.equal('fixed');
+      await testCollection(db).deleteOne({ _id });
+    });
+  });
+
+
+
+
+
+
   after(() => Promise.all([
     cleanAndCloseDb(db),
     close(),

--- a/test/lib/routers/documentSpec.js
+++ b/test/lib/routers/documentSpec.js
@@ -110,11 +110,7 @@ describe('Router document', () => {
   it('DEL /db/<dbName>/<collection>/<document> should delete the document');
   it('PUT /db/<dbName>/<collection>/<document> should update the document');
 
-
-
-
-
-   describe('Document with a $-prefixed field name', () => {
+  describe('Document with a $-prefixed field name', () => {
     it('should update a document that has a $-prefixed field', async () => {
       const _id = new ObjectId();
       await testCollection(db).insertOne({ _id, weird: { $concatArrays: ['$a', ['b']] } });
@@ -128,11 +124,6 @@ describe('Router document', () => {
       await testCollection(db).deleteOne({ _id });
     });
   });
-
-
-
-
-
 
   after(() => Promise.all([
     cleanAndCloseDb(db),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongo-express/mongo-express/1927)
- - -
<!-- Reviewable:end -->
Fixes #1640

## Problem

Documents that contain a field name starting with `$` (however that field
got created) cannot be edited or deleted through mongo-express. Attempting
either action fails with:

MongoServerError: unknown operator: $<field name>

## Root cause

In `lib/routes/document.js`, both `updateDocument` and `deleteDocument`
used the entire original document (`req.document`) as the MongoDB filter:

    await req.collection.replaceOne(req.document, docBSON)
    await req.collection.deleteOne(req.document)

When the document contains a field like `oldEmail.$concatArrays`, MongoDB
parses that key in the filter as a query operator (since it starts with
`$`). Since no such operator exists in that context, the query is rejected
before the update/delete can even run.

## Fix

Filter by `_id` only, since it's already guaranteed unique and is
sufficient to identify the exact document:

    await req.collection.replaceOne({ _id: req.document._id }, docBSON)
    await req.collection.deleteOne({ _id: req.document._id })

## Testing

Added a regression test that inserts a document with a `$`-prefixed
nested field and confirms it can be updated through the route. Before
this fix, the test fails with the exact `unknown operator` error from
the original issue; after the fix, it passes.